### PR TITLE
Correct names of the GCP instance groups

### DIFF
--- a/gcp/prepare-env-manual.html.md.erb
+++ b/gcp/prepare-env-manual.html.md.erb
@@ -526,9 +526,9 @@ If you are deploying **PAS or other runtimes**, proceed to the following step.
     * **Protocol**: `HTTP`.
     * **Named port**: `http`.
     * **Timeout**: `10 seconds`.  
-    * Under **Backends** > **New backend**, select the **Instance group** that corresponds to the first zone of the multi-zone instance group you created. For example: `MY-PCF-http-lb-us-west1-a`. Click **Done**.
-    * Click **Add backend**, select the **Instance group** that corresponds to the second zone of the multi-zone instance group you created. For example: `MY-PCF-http-lb-us-west1-b`. Click **Done**.
-    * Click **Add backend**, select the **Instance group** that corresponds to the third zone of the multi-zone instance group you created. For example: `MY-PCF-http-lb-us-west1-c`. Click **Done**.
+    * Under **Backends** > **New backend**, select the **Instance group** that corresponds to the first zone of the multi-zone instance group you created. For example: `MY-PCF-http-lb (us-west1-a)`. Click **Done**.
+    * Click **Add backend**, select the **Instance group** that corresponds to the second zone of the multi-zone instance group you created. For example: `MY-PCF-http-lb (us-west1-b)`. Click **Done**.
+    * Click **Add backend**, select the **Instance group** that corresponds to the third zone of the multi-zone instance group you created. For example: `MY-PCF-http-lb (us-west1-c)`. Click **Done**.
     * **Health check**: Select the `MY-PCF-cf-public` health check that you created.  
     * **Cloud CDN**: Ensure Cloud CDN is disabled. 
  


### PR DESCRIPTION
The group names are all MY-PCF-http-lb from the steps above, but the
regions are shown in paranthesis. Correcting to match.