### PR TITLE
GCP: note auto storage scaling enabled

### DIFF
--- a/gcp/prepare-env-manual.html.md.erb
+++ b/gcp/prepare-env-manual.html.md.erb
@@ -407,7 +407,9 @@ If you are deploying **PAS or other runtimes**, proceed to the following step.
   * **Root password**: Set a password for the root user.
   * **Region**: Select the region you specified when creating networks.
   * **Zone**: `Any`. 
-  * **Configure machine type and storage**: Click **Change** and then select `db-n1-standard-2`.
+  * **Configure machine type and storage**:
+     * Click **Change** and then select `db-n1-standard-2`.
+     * Ensure that `Enable automatic storage increases` is checked. This will allow the DB storage to grow automatically when space is required.
   * **Enable auto backups and high availability**: Make the following selections:
      * Leave **Automate backups** and **Enable binary logging** selected. 
      * Under **High availability**, select the **Create failover replica** checkbox. 


### PR DESCRIPTION
For internal MySQL we have a minimum 10GB disk and recommend a
30GB disk. For GCP however, we can stick with the default (10GB)
and simply ensure that "Enable automatic storage increases" is set.
This will let GCP Cloud SQL automatically scale storage as needed
rather than setting a higher minimum. Although this setting is
default enabled, we should note that it should be checked since
we are starting with the effective minimum amount of storage (10GB).