### PR TITLE
Private Google access for private deployments

### DIFF
--- a/gcp/prepare-env-manual.html.md.erb
+++ b/gcp/prepare-env-manual.html.md.erb
@@ -102,6 +102,7 @@ Ops Manager manages GCP resources using the Google Compute Engine and Cloud Reso
       </table><br>
       See the following image for an example:
       ![Create VPC Subnet](../common/images/gcp/gcp-vpc-subnet.png)
+      <p class="note"><strong>Note:</strong> For deployments that do not use external IP addresses, <strong>Private Google access</strong> should be enabled to allow Cloud Foundry to make API calls to Google services.</p>
     1. Click **Add subnet** to add a second subnet for the BOSH Director and components specific to your runtime. Complete the form as follows:
       <table>
         <tr>

--- a/gcp/prepare-env-manual.html.md.erb
+++ b/gcp/prepare-env-manual.html.md.erb
@@ -102,7 +102,7 @@ Ops Manager manages GCP resources using the Google Compute Engine and Cloud Reso
       </table><br>
       See the following image for an example:
       ![Create VPC Subnet](../common/images/gcp/gcp-vpc-subnet.png)
-      <p class="note"><strong>Note:</strong> For deployments that do not use external IP addresses, <strong>Private Google access</strong> should be enabled to allow Cloud Foundry to make API calls to Google services.</p>
+      <p class="note"><strong>Note:</strong> For deployments that do not use external IP addresses, enable <strong>Private Google access</strong> to allow Cloud Foundry to make API calls to Google services.</p>
     1. Click **Add subnet** to add a second subnet for the BOSH Director and components specific to your runtime. Complete the form as follows:
       <table>
         <tr>


### PR DESCRIPTION
For deployments that do not use external (Public) IPs, Private Google
access needs to be enabled so that Pivotal Cloud Foundry can make API
calls. PCF uses these calls to create & manage stemcells, VMs, etc.