### PR TITLE
Typo in AWS PCF manual install steps

### DIFF
--- a/aws/prepare-env-manual.html.md.erb
+++ b/aws/prepare-env-manual.html.md.erb
@@ -440,7 +440,7 @@ Perform the following steps to create an Amazon Identity and Access Management (
 
 1. From the **Security Groups** page, click **Create Security Group** to create another security group.
 
-1. For **Security group name**, enter `MySQL`.
+1. For **Security group name**, enter `pcf-mysql-security-group`.
 
 1. For **Description**, enter a description to identify this security group.
 


### PR DESCRIPTION
This guide leads the user to name the Security Group for MySQL as "MySQL." Further throughout the documentation, the same Security Group is mentioned as "pcf-mysql-security-group."