### PR TITLE
Fixed the CIDR for the proposed network resources

### DIFF
--- a/azure/deploy-manual.html.md.erb
+++ b/azure/deploy-manual.html.md.erb
@@ -113,12 +113,12 @@ Before you perform the procedures in this topic, you must have completed the pro
     $ az network vnet subnet create --name Deployment \
     --vnet-name PCF \
     --resource-group $RESOURCE_GROUP \
-    --address-prefix 10.0.12.0/20 \
+    --address-prefix 10.0.12.0/22 \
     --network-security-group pcf-nsg
     $ az network vnet subnet create --name Services \
     --vnet-name PCF \
     --resource-group $RESOURCE_GROUP \
-    --address-prefix 10.0.8.0/20 \
+    --address-prefix 10.0.8.0/22 \
     --network-security-group pcf-nsg
     </pre>
 


### PR DESCRIPTION
The /20 CIDR for Deployment and Services is not compatible with the CIDR mentioned in the `Configuring BOSH Director on Azure` section. Azure will give you an error :

```
The address prefix 10.0.12.0/20 in resource /subscriptions/XXXXXXXXXXXX/resourceGroups/XXX/providers/Microsoft.Network/virtualNetworks/PCF/subnets/Deployment has an invalid CIDR notation. For the given prefix length, the address prefix should be 10.0.0.0/20.
```