### PR TITLE
Update PAS 2.4 - Azure manual install steps

### DIFF
--- a/azure/deploy-manual.html.md.erb
+++ b/azure/deploy-manual.html.md.erb
@@ -50,28 +50,28 @@ procedures in this topic.</p>
     $ az network nsg rule create --name ssh \
     --nsg-name pcf-nsg --resource-group $RESOURCE\_GROUP \
     --protocol Tcp --priority 100 \
-    --destination-port-range '22'
+    --destination-port-ranges '22'
     </pre>
     <pre class="terminal">
     $ az network nsg rule create --name http \
     --nsg-name pcf-nsg --resource-group $RESOURCE\_GROUP \
     --protocol Tcp --priority 200 \
-    --destination-port-range '80'
+    --destination-port-ranges '80'
     </pre>
     <pre class="terminal">
     $ az network nsg rule create --name https \
     --nsg-name pcf-nsg --resource-group $RESOURCE\_GROUP \
     --protocol Tcp --priority 300 \
-    --destination-port-range '443'
+    --destination-port-ranges '443'
     </pre>
     <pre class="terminal">
     $ az network nsg rule create --name diego-ssh \
     --nsg-name pcf-nsg --resource-group $RESOURCE\_GROUP \
     --protocol Tcp --priority 400 \
-    --destination-port-range '2222'
+    --destination-port-ranges '2222'
     </pre>
-   * To block traffic from the public Internet, append `--source-address-range AzureLoadBalancer` to allow traffic from only the Azure load balancer or `--source-address-range VirtualNetwork` to only allow traffic from the virtual network.
-   * To allow traffic from both the Azure load balancer and the virtual network, create duplicates of each rule, one specifying `--source-address-range AzureLoadBalancer` and one specifying `--source-address-range VirtualNetwork`.
+   * To block traffic from the public Internet, append `--source-address-prefixes AzureLoadBalancer` to allow traffic from only the Azure load balancer or `--source-address-prefixes VirtualNetwork` to only allow traffic from the virtual network.
+   * To allow traffic from both the Azure load balancer and the virtual network, create duplicates of each rule, one specifying `--source-address-prefixes AzureLoadBalancer` and one specifying `--source-address-prefixes VirtualNetwork`.
 
 1. Create a network security group named `opsmgr-nsg`.
     <pre class="terminal">
@@ -85,7 +85,7 @@ procedures in this topic.</p>
     $ az network nsg rule create --name http \
     --nsg-name opsmgr-nsg --resource-group $RESOURCE_GROUP \
     --protocol Tcp --priority 100 \
-    --destination-port-range 80
+    --destination-port-ranges 80
     </pre>
 
 1. Add a network security group rule to the `opsmgr-nsg` group to allow HTTPS traffic to the Ops Manager VM.
@@ -93,7 +93,7 @@ procedures in this topic.</p>
     $ az network nsg rule create --name https \
     --nsg-name opsmgr-nsg --resource-group $RESOURCE_GROUP \
     --protocol Tcp --priority 200 \
-    --destination-port-range 443
+    --destination-port-ranges 443
     </pre>
 
 1. Add a network security group rule to the `opsmgr-nsg` group to allow SSH traffic to the Ops Manager VM.
@@ -101,22 +101,22 @@ procedures in this topic.</p>
     $ az network nsg rule create --name ssh \
     --nsg-name opsmgr-nsg --resource-group $RESOURCE_GROUP \
     --protocol Tcp --priority 300 \
-    --destination-port-range 22
+    --destination-port-ranges 22
     </pre>
-    <p class='note'><strong>Note:</strong> To block traffic from the public Internet, append <code>--source-address-range AzureLoadBalancer</code> to allow traffic from only the Azure load balancer or <code>--source-address-range VirtualNetwork</code> to only allow traffic from the virtual network. To allow traffic from both the Azure load balancer and the virtual network, create duplicates of each rule, one specifying <code>--source-address-range AzureLoadBalancer</code> and one specifying <code>--source-address-range VirtualNetwork</code>.</p>
+    <p class='note'><strong>Note:</strong> To block traffic from the public Internet, append <code>--source-address-prefixes AzureLoadBalancer</code> to allow traffic from only the Azure load balancer or <code>--source-address-prefixes VirtualNetwork</code> to only allow traffic from the virtual network. To allow traffic from both the Azure load balancer and the virtual network, create duplicates of each rule, one specifying <code>--source-address-prefixes AzureLoadBalancer</code> and one specifying <code>--source-address-prefixes VirtualNetwork</code>.</p>
     Optionally, if you want to use private IP ranges with Ops Manager and allow all internal traffic, you can create the Network Security Groups to allow all internal traffic.
     <pre class="terminal">
     $ az network nsg rule create --name internal-virtual-network \
     --nsg-name internal-traffic --resource-group $RESOURCE_GROUP \
     --protocol Tcp --priority 100 \
-    --destination-port-range *
-    --source-address-range VirtualNetwork
+    --destination-port-ranges '*' \
+    --source-address-prefixes VirtualNetwork
 
      $ az network nsg rule create --name internal-from-lb \
     --nsg-name internal-traffic --resource-group $RESOURCE_GROUP \
     --protocol Tcp --priority 110 \
-    --destination-port-range *
-    --source-address-range AzureLoadBalancer
+    --destination-port-ranges '*'
+    --source-address-prefixes AzureLoadBalancer
     </pre>
 
 1. Create a virtual network named `pcf-virtual-network`.
@@ -368,18 +368,18 @@ Your load balancer configuration depends on whether you want apps to be availabl
 1. Export the Ops Manager image URL as an environment variable.
     <pre class="terminal">$ export OPS\_MAN\_IMAGE\_URL="YOUR-OPS-MAN-IMAGE-URL"</pre>
 
-1. Download the Ops Manager image. For compatibility when upgrading to future versions of Ops Manager, choose a unique name for the image that includes the Ops Manager version number. For example, replace <code>opsman-image-2.3.x</code> in the following examples with <code>opsman-image-2.3.1</code>.
+1. Download the Ops Manager image. For compatibility when upgrading to future versions of Ops Manager, choose a unique name for the image that includes the Ops Manager version number. For example, replace <code>opsman-image-2.4.x</code> in the following examples with <code>opsman-image-2.4.1</code>.
   * If you use unmanaged disks, perform the following steps:
   <p class="note"><strong>Note:</strong> Azure Stack requires unmanaged disks.</p>
       1. Download the Ops Manager image to your local machine. The image size is 10&nbsp;GB.
-        <pre class="terminal">$ wget $OPS\_MAN\_IMAGE\_URL -O opsman-image-2.3.x.vhd</pre>
+        <pre class="terminal">$ wget $OPS\_MAN\_IMAGE\_URL -O opsman-image-2.4.x.vhd</pre>
       1. Upload the image to your storage account using the Azure CLI.
         <pre class="terminal">
-        $ az storage blob upload --name opsman-image-2.3.x.vhd \
+        $ az storage blob upload --name opsman-image-2.4.x.vhd \
         --connection-string $CONNECTION\_STRING \
         --container-name opsmanager \
         --type page \
-        --file opsman-image-2.3.x.vhd
+        --file opsman-image-2.4.x.vhd
         </pre>
   * If you use managed disks, do the following:
        1. Copy the Ops Manager image into your storage account using the Azure CLI.
@@ -387,11 +387,11 @@ Your load balancer configuration depends on whether you want apps to be availabl
         $ az storage blob copy start --source-uri $OPS\_MAN\_IMAGE\_URL \
         --connection-string $CONNECTION\_STRING \
         --destination-container opsmanager \
-        --destination-blob opsman-image-2.3.x.vhd
+        --destination-blob opsman-image-2.4.x.vhd
         </pre>
        1. Copying the image may take several minutes. Run the following command and examine the output under `"copy"`:
         <pre class="terminal">
-        $ az storage blob show --name opsman-image-2.3.x.vhd \
+        $ az storage blob show --name opsman-image-2.4.x.vhd \
         --container-name opsmanager \
         --connection-string $CONNECTION_STRING
         ...
@@ -399,7 +399,7 @@ Your load balancer configuration depends on whether you want apps to be availabl
           "completionTime": "2017-06-26T22:24:11+00:00",
           "id": "b9c8b272-a562-4574-baa6-f1a04afcefdf",
           "progress": "53687091712/53687091712",
-          "source": "http<span>s:/</span>/opsmanagerwestus.blob.core.windows.net/images/opsman-image-2.3.x.vhd",
+          "source": "http<span>s:/</span>/opsmanagerwestus.blob.core.windows.net/images/opsman-image-2.4.x.vhd",
           "status": "success",
           "statusDescription": null
         },
@@ -456,11 +456,11 @@ Your load balancer configuration depends on whether you want apps to be availabl
 1. Create the Ops Manager VM.
     * If you are using unmanaged disks, run the following command to create your Ops Manager VM, replacing `PATH-TO-PUBLIC-KEY` with the path to your public key .pub file:
         <pre class="terminal">
-        $ az vm create --name opsman-2.3.x --resource-group $RESOURCE_GROUP \
+        $ az vm create --name opsman-2.4.x --resource-group $RESOURCE_GROUP \
         --location $LOCATION \
         --nics opsman-nic \
-        --image https://$STORAGE_NAME.my-azure-instance.com/opsmanager/opsman-image-2.3.x.vhd \
-        --os-disk-name opsman-2.3.x-osdisk \
+        --image https://$STORAGE_NAME.my-azure-instance.com/opsmanager/opsman-image-2.4.x.vhd \
+        --os-disk-name opsman-2.4.x-osdisk \
         --os-disk-size-gb 128 \
         --os-type Linux \
         --use-unmanaged-disk \
@@ -474,8 +474,8 @@ Your load balancer configuration depends on whether you want apps to be availabl
         1. Create a managed image from the Ops Manager VHD file:
             <pre class="terminal">
             $ az image create --resource-group $RESOURCE_GROUP \
-            --name opsman-image-2.3.x \
-            --source https://$STORAGE_NAME.blob.core.windows.net/opsmanager/image-2.3.x.vhd \
+            --name opsman-image-2.4.x \
+            --source https://$STORAGE_NAME.blob.core.windows.net/opsmanager/image-2.4.x.vhd \
             --location $LOCATION \
             --os-type Linux
             </pre>
@@ -485,12 +485,12 @@ Your load balancer configuration depends on whether you want apps to be availabl
             * For Azure Germany, use `blob.core.cloudapi.de`. See the [Azure documentation](https://docs.microsoft.com/en-us/azure/germany/germany-developer-guide) for more information.
         1. Create your Ops Manager VM, replacing `PATH-TO-PUBLIC-KEY` with the path to your public key `.pub` file.
             <pre class="terminal">
-             $ az vm create --name opsman-2.3.x --resource-group $RESOURCE\_GROUP \
+             $ az vm create --name opsman-2.4.x --resource-group $RESOURCE\_GROUP \
              --location $LOCATION \
              --nics opsman-nic \
-             --image opsman-image-2.3.x \
+             --image opsman-image-2.4.x \
              --os-disk-size-gb 128 \
-             --os-disk-name opsman-2.3.x-osdisk \
+             --os-disk-name opsman-2.4.x-osdisk \
              --admin-username ubuntu \
              --size Standard\_DS2_v2 \
              --storage-sku Standard\_LRS \
@@ -501,17 +501,17 @@ Your load balancer configuration depends on whether you want apps to be availabl
     <p class="note"><strong>Note:</strong> If you use Azure Stack, you must increase the Ops Manager VM disk size using the Azure Stack UI.</p>
     1. Run the following command to stop the VM and detach the disk:
     <pre class="terminal">
-    $ az vm deallocate --name opsman-2.3.x \
+    $ az vm deallocate --name opsman-2.4.x \
     --resource-group $RESOURCE\_GROUP
     </pre>
     1. Run the following command to resize the disk to 128&nbsp;GB:
     <pre class="terminal">
-    $ az disk update --size-gb 128 --name opsman-2.3.x-osdisk \
+    $ az disk update --size-gb 128 --name opsman-2.4.x-osdisk \
     --resource-group $RESOURCE\_GROUP
     </pre>
     1. Run the following command to start the VM:
     <pre class="terminal">
-    $ az vm start --name opsman-2.3.x --resource-group $RESOURCE\_GROUP
+    $ az vm start --name opsman-2.4.x --resource-group $RESOURCE\_GROUP
     </pre>
 
 


### PR DESCRIPTION
While manually installing PAS 2.4 on Azure using a recent Azure CLI `v2.0.58`, I noticed that some options listed in the Docs for commands to create `nsg`s are not correct. Also, the PAS 2.4 instructions had mentions of 2.3 in it. Both issues are addressed in this PR. Thanks!