### PR TITLE
document the usage of not creating an Ops Manager VM

### DIFF
--- a/aws/prepare-env-terraform.html.md.erb
+++ b/aws/prepare-env-terraform.html.md.erb
@@ -109,7 +109,13 @@ for your runtime.
     </tr>
     <tr>
       <td><code>YOUR-OPS-MAN-IMAGE-AMI</code></td>
-      <td>Enter the source code for the Ops Manager Amazon Machine Image (AMI) you want to boot. You can find this code in the PDF included with the Ops Manager release on <a href="https://network.pivotal.io/">Pivotal Network</a>.<br><br>If you want to encrypt your Ops Manager VM, create an encrypted AMI copy from the AWS EC2 dashboard and enter the source code for the coped Ops Manager image instead. For more information about copying an AMI, see step 9 of [Launch an Ops Manager AMI](config-manual.html#pcfaws-om-ami) in the manual AWS configuration topic.</td>
+      <td>
+        Enter the source code for the Ops Manager Amazon Machine Image (AMI) you want to boot. You can find this code in the PDF included with the Ops Manager release on <a href="https://network.pivotal.io/">Pivotal Network</a>.
+        <br><br>
+        If you want to encrypt your Ops Manager VM, create an encrypted AMI copy from the AWS EC2 dashboard and enter the source code for the coped Ops Manager image instead. For more information about copying an AMI, see step 9 of [Launch an Ops Manager AMI](config-manual.html#pcfaws-om-ami) in the manual AWS configuration topic.
+        <br><br>
+        Setting this value to an empty string (<code>""</code>) will not create an Ops Manager VM. When using <a href="/platform-automation">Platform Automation</a> it is required to disable the creation of the Ops Manager VM from terraform. Platform Automation tools can create, delete, and upgrade an Ops Manager VM.
+      </td>
     </tr>
     <tr>
       <td><code>YOUR-DNS-SUFFIX</code></td>

--- a/azure/prepare-env-terraform.html.md.erb
+++ b/azure/prepare-env-terraform.html.md.erb
@@ -100,7 +100,11 @@ about locating your Azure service principal values, see [Preparing to Deploy Ops
     </tr>
     <tr>
       <td><code>YOUR-OPS-MAN-IMAGE-URI</code></td>
-      <td>Enter the URL for the Ops Manager Azure image you want to boot. You can find this code in the PDF included with the Ops Manager release on <a href="https://network.pivotal.io/">Pivotal Network</a>.</td>
+      <td>
+        Enter the URL for the Ops Manager Azure image you want to boot. You can find this code in the PDF included with the Ops Manager release on <a href="https://network.pivotal.io/">Pivotal Network</a>.
+        <br><br>
+        Setting this value to an empty string (<code>""</code>) will not create an Ops Manager VM. When using <a href="/platform-automation">Platform Automation</a> it is required to disable the creation of the Ops Manager VM from terraform. Platform Automation tools can create, delete, and upgrade an Ops Manager VM.
+      </td>
     </tr>
     <tr>
       <td><code>YOUR-DNS-SUFFIX</code></td>

--- a/gcp/prepare-env-terraform.html.md.erb
+++ b/gcp/prepare-env-terraform.html.md.erb
@@ -128,7 +128,11 @@ the Terraform files for your runtime.
     </tr>
     <tr>
       <td><code>YOUR-OPS-MAN-IMAGE-URL</code></td>
-      <td>Enter the source URL of the Ops Manager image you want to boot. You can find this URL in the PDF included with the Ops Manager release on <a href="https://network.pivotal.io/">Pivotal Network</a>.</td>
+      <td>
+        Enter the source URL of the Ops Manager image you want to boot. You can find this URL in the PDF included with the Ops Manager release on <a href="https://network.pivotal.io/">Pivotal Network</a>.
+        <br><br>
+        Setting this value to an empty string (<code>""</code>) will not create an Ops Manager VM. When using <a href="/platform-automation">Platform Automation</a> it is required to disable the creation of the Ops Manager VM from terraform. Platform Automation tools can create, delete, and upgrade an Ops Manager VM.
+      </td>
     </tr>
     <tr>
       <td><code>YOUR-GCP-REGION</code></td>


### PR DESCRIPTION
**WARNING: Only accept on GA of Platform Automation.**

When using platform automation, an Ops Manager VM does not need to be created via the terraform scripts.
We are documenting that this feature can be disabled and then where to read more information about Platform Automation.
[#161932321]

Signed-off-by: John McBride <jmcbride@pivotal.io>