### PR TITLE
Fix scripts and load balancer health probe path

### DIFF
--- a/azure/deploy-manual.html.md.erb
+++ b/azure/deploy-manual.html.md.erb
@@ -108,13 +108,13 @@ procedures in this topic.</p>
     $ az network nsg rule create --name internal-virtual-network \
     --nsg-name internal-traffic --resource-group $RESOURCE_GROUP \
     --protocol Tcp --priority 100 \
-    --destination-port-range *
+    --destination-port-range * \
     --source-address-range VirtualNetwork
 
     $ az network nsg rule create --name internal-from-lb \
     --nsg-name internal-traffic --resource-group $RESOURCE_GROUP \
     --protocol Tcp --priority 110 \
-    --destination-port-range *
+    --destination-port-range * \
     --source-address-range AzureLoadBalancer
     </pre>
 
@@ -261,7 +261,7 @@ Your load balancer configuration depends on whether you want apps to be availabl
         <pre class="terminal">
         $ az network lb probe create --lb-name pcf-lb \
         --name http8080 --resource-group $RESOURCE_GROUP \
-        --protocol Http --port 8080 --path \
+        --protocol Http --port 8080 --path health
         </pre>
     1. Add a load balancing rule for HTTP.
         <pre class="terminal">


### PR DESCRIPTION
The documented path of `\` is incorrect and results in a failed PAS deployment. According to the load balancer health check doc, the correct path is `health`.

https://docs.pivotal.io/pivotalcf/2-5/adminguide/configure-lb-healthcheck.html