### PR TITLE
Add variable to use with terraform output for iam profile config

### DIFF
--- a/aws/config-terraform.html.md.erb
+++ b/aws/config-terraform.html.md.erb
@@ -56,7 +56,7 @@ To complete the procedures in this topic, you must have access to the output fro
     * If you choose to use AWS keys, complete the following fields:
         * **Access Key ID**: Enter the value of `ops_manager_iam_user_access_key` from the Terraform output.
         * **AWS Secret Key**: Enter the value of `ops_manager_iam_user_secret_key` from the Terraform output.
-    * If you choose to use an AWS instance profile, enter the name of your AWS Identity and Access Management (IAM) profile.
+    * If you choose to use an AWS instance profile, enter the name of your AWS Identity and Access Management (IAM) profile or enter the value of `ops_manager_iam_instance_profile_name` from the Terraform output.
 
 1. Complete the remainder of the **AWS Management Console Config** page with the following information.
     * **Security Group ID**: Enter the value of `vms_security_group_id` from the Terraform output.


### PR DESCRIPTION
The IAM profile section of the AWS director config didn't list the terraform output variable you could use. 