### PR TITLE
Fixed "VPC Subnet ID" under "Second Subnet"

### DIFF
--- a/aws/config-terraform.html.md.erb
+++ b/aws/config-terraform.html.md.erb
@@ -322,7 +322,7 @@ To complete the procedures in this topic, you must have access to the output fro
       </tr>
       <tr>
         <th>VPC Subnet ID</th>
-        <td>The second value of <code>services_subnet_availability_zones</code> from the Terraform output.</td>
+        <td>The second value of <code>services_subnet_ids</code> from the Terraform output.</td>
       </tr>
       <tr>
         <th>CIDR</th>


### PR DESCRIPTION
In "Step 5: Create Networks Page" section the "VPC Subnet ID" under "Second Subnet" had the incorrect value of "services_subnet_availability_zones" when it should be "services_subnet_ids"