### PR TITLE
Clarify Step 1: Access Ops Manager username/email

### DIFF
--- a/aws/config-terraform.html.md.erb
+++ b/aws/config-terraform.html.md.erb
@@ -40,10 +40,10 @@ To complete the procedures in this topic, you must have access to the output fro
 
     <%= image_tag("../common/images/om-login.png") %>
 
-1. Log in to Ops Manager with the Admin username and password you created in the previous step.
+1. Log in to Ops Manager with the Admin *username and password you created in the previous step.
 
     <%= image_tag("../common/images/cf-login.png") %>
-
+`*` The prompt for username could actually say "email" as this field is customizable.
 ### <a id='saml'></a> SAML Identity Provider
 
 <%= partial '../common/using_saml_idp_ops_manager' %>


### PR DESCRIPTION
`*` The prompt for username could actually say "email" as this field is customizable. It was misleading to me that in the previous step I created a username, but the prompt was asking for an "email" to authenticate.