### PR TITLE
Removed ref to step 9 from Download Templates sec

### DIFF
--- a/aws/prepare-env-terraform.html.md.erb
+++ b/aws/prepare-env-terraform.html.md.erb
@@ -112,7 +112,7 @@ for your runtime.
       <td>
         Enter the source code for the Ops Manager Amazon Machine Image (AMI) you want to boot. You can find this code in the PDF included with the Ops Manager release on <a href="https://network.pivotal.io/products/ops-manager">Pivotal Network</a>.
         <br><br>
-        If you want to encrypt your Ops Manager VM, create an encrypted AMI copy from the AWS EC2 dashboard and enter the source code for the copied Ops Manager image instead. For more information about copying an AMI, see step 9 of [Launch an Ops Manager AMI](prepare-env-manual.html#pcfaws-om-ami) in the manual AWS configuration topic.
+        If you want to encrypt your Ops Manager VM, create an encrypted AMI copy from the AWS EC2 dashboard and enter the source code for the copied Ops Manager image instead. For more information about copying an AMI, use [Launch an Ops Manager AMI](prepare-env-manual.html#pcfaws-om-ami) in the manual AWS configuration topic.
         <br><br>
         To prevent the creation of an Ops Manager VM, set this value to an empty string (<code>""</code>). When using <a href="https://docs.pivotal.io/platform-automation">Platform Automation</a>, you must disable the creation of the Ops Manager VM from Terraform. Platform Automation tools can create, delete, and upgrade an Ops Manager VM.
       </td>


### PR DESCRIPTION
In the Step 1: Download Templates and Edit Variables File section, it's 9th bullet where it states "see step 9 from..." well that link is accurate, but it is not step 12. Considering the nature of markdown I suggest we just change the wording to ```use <link> in the manual AWS configuration topic.```