### PR TITLE
Added GCP bucket for blobstore backup

### DIFF
--- a/gcp/prepare-env-manual.html.md.erb
+++ b/gcp/prepare-env-manual.html.md.erb
@@ -488,6 +488,7 @@ If you are deploying **PAS or other runtimes**, proceed to the following step.
   * `pcf-droplets`
   * `pcf-packages`
   * `pcf-resources`
+  * `pcf-backup`
 
 
 ## <a id="loadbalancer"></a> Step 8: Create HTTP Load Balancer


### PR DESCRIPTION
This change only applies to 2.6+
Story here: https://www.pivotaltracker.com/story/show/158789077
[#158789077]

Co-authored-by: Jake Klein <jklein@pivotal.io>