### PR TITLE
Need to specify the path for a probe to the LB

### DIFF
--- a/azure/deploy-manual.html.md.erb
+++ b/azure/deploy-manual.html.md.erb
@@ -262,7 +262,7 @@ To create load balancers, do the following:
         <pre class="terminal">
         $ az network lb probe create --lb-name pcf-lb \
         --name http8080 --resource-group $RESOURCE_GROUP \
-        --protocol Http --port 8080 --path \
+        --protocol Http --port 8080 --path health
         </pre>
     1. Add a load balancing rule for HTTP.
         <pre class="terminal">


### PR DESCRIPTION
According to docs for PCF 2.6, set "health" as the path fo a probe to the load balancer