### PR TITLE
Policy update for terraform

### DIFF
--- a/aws/prepare-env-terraform.html.md.erb
+++ b/aws/prepare-env-terraform.html.md.erb
@@ -29,6 +29,7 @@ In addition to reviewing the prerequisites for your runtime, ensure you have the
   * AmazonVPCFullAccess
   * IAMFullAccess
   * AWSKeyManagementServicePowerUser
+  * and a policy with kms:UpdateKeyDescription action allowed.
 
 
 ## <a id="download"></a> Step 1: Download Templates and Edit Variables File


### PR DESCRIPTION
Added kms:UpdateKeyDescription policy requirement from Terraform
Terraform gives an Access Denied exception when the user provided doesn't have the above policy added as well.