### PR TITLE
Typo in Create Availability Zones Page

### DIFF
--- a/aws/config-terraform.html.md.erb
+++ b/aws/config-terraform.html.md.erb
@@ -98,7 +98,7 @@ To complete the procedures in this topic, you must have access to the output fro
 1. To create three Availability Zones for your apps to use, do the following:
     1. Click **Add** three times.
     1. For **Amazon Availability Zone**, enter the values corresponding
-    to the key `infrastucture_subnet_availability_zones` from the Terraform output.
+    to the key `infrastructure_subnet_availability_zones` from the Terraform output.
     1. Click **Save**.
 
 


### PR DESCRIPTION
For Amazon Availability Zone, enter the values corresponding to the key **infrastucture_subnet_availability_zones** from the Terraform output.
 to
For Amazon Availability Zone, enter the values corresponding to the key **infrastructure_subnet_availability_zones** from the Terraform output.