### PR TITLE
Subnet name should be updated based on PAS rather than ERT

### DIFF
--- a/aws/prepare-env-manual.html.md.erb
+++ b/aws/prepare-env-manual.html.md.erb
@@ -149,17 +149,17 @@ Perform the following steps to create an Amazon Identity and Access Management (
        <td>`10.0.16.32/28`</td>
      </tr>
      <tr>
-       <td>`pcf-ert-subnet-az0`</td>
+       <td>`pcf-pas-subnet-az0`</td>
        <td>`REGION-#a` (for example, `us-west-2a`)</td>
        <td>`10.0.4.0/24`</td>
      </tr>
      <tr>
-       <td>`pcf-ert-subnet-az1`</td>
+       <td>`pcf-pas-subnet-az1`</td>
        <td>`REGION-#b` (for example, `us-west-2b`)</td>
        <td>`10.0.5.0/24`</td>
      </tr>
      <tr>
-       <td>`pcf-ert-subnet-az2`</td>
+       <td>`pcf-pas-subnet-az2`</td>
        <td>`REGION-#c` (for example, `us-west-2c`)</td>
        <td>`10.0.6.0/24`</td>
      </tr>


### PR DESCRIPTION
At the Step 4, the required pas neworks name is like "pcf-ert-subnet-[az name]." This is derived from Elastic Runtime - former name of PAS. They should be like "pcf-pas-subnet-[az name]." Actually, the Step 5 of the following docs, it asks the customer to create PAS networks with its name like "pcf-pas-subnet-[az name]." This naming rule inconsistency could confuse the customer.

https://docs.pivotal.io/platform/ops-manager/2-5/aws/config-manual.html#network

I see this inconsistency with the same docs for newer version of PAS. 