### PR TITLE
Add updated vSphere 6.7 privileges

### DIFF
--- a/vsphere/vsphere-service-account.html.md.erb
+++ b/vsphere/vsphere-service-account.html.md.erb
@@ -71,6 +71,7 @@ You must grant the following privileges on any entities in a datacenter where yo
     <tr><td>Allocate space</td><td>Datastore.AllocateSpace</td></tr>
     <tr><td>Browse datastore</td><td>Datastore.Browse</td></tr>
     <tr><td>Remove file</td><td>Datastore.DeleteFile</td></tr>
+    <tr><td>Remove file</td><td>Datastore.FileManagement</td></tr>
     <tr><td>Update virtual machine files</td><td>Datastore.UpdateVirtualMachineFiles</td></tr>
 </table>
 
@@ -143,6 +144,17 @@ When using `vAppImport` to clone a VM, BOSH requires the resource migration priv
     <tr><td>Migrate powered on virtual machine</td><td>Resource.HotMigrate</td></tr>
 </table>
 
+### <a id="storageprofile"></a>Profile-driven Storage Object
+
+<table>
+    <tr>
+      <th>Privilege (UI)</th>
+      <th>Privilege (API)</th>
+    </tr>
+    <tr><td>Profile-driven storage update</td><td>StorageProfile.Update</td></tr>
+    <tr><td>Profile-driven storage view</td><td>StorageProfile.View</td></tr>
+</table>
+
 ### <a id="vm"></a>Virtual Machine Object
 
 #### <a id='configuration'></a> Configuration
@@ -174,7 +186,7 @@ When using `vAppImport` to clone a VM, BOSH requires the resource migration priv
     <tr><td>Settings</td><td>VirtualMachine.Config.Settings</td></tr>
     <tr><td>Swapfile placement</td><td>VirtualMachine.Config.SwapPlacement</td></tr>
     <tr><td>Unlock virtual machine</td><td>VirtualMachine.Config.Unlock</td></tr>
-    <tr><td>Upgrade virtual machine hardware</td><td>VirtualMachine.Config.UpgradeVirtualHardware</td></tr>
+    <tr><td>Upgrade virtual machine compatibility</td><td>VirtualMachine.Config.UpgradeVirtualHardware</td></tr>
 </table>
 
 #### <a id='guest-operations'></a> Guest Operations
@@ -198,8 +210,8 @@ When using `vAppImport` to clone a VM, BOSH requires the resource migration priv
     </tr>
     <tr><td>Answer question</td><td>VirtualMachine.Interact.AnswerQuestion</td></tr>
     <tr><td>Configure CD media</td><td>VirtualMachine.Interact.SetCDMedia</td></tr>
-    <tr><td>Interact with VM’s mouse, keyboard, and screen</td><td>VirtualMachine.Interact.ConsoleInteract</td></tr>
-    <tr><td>Defragment operations on any VM disk</td><td>VirtualMachine.Interact.DefragmentAllDisks</td></tr>
+    <tr><td>Console interaction</td><td>VirtualMachine.Interact.ConsoleInteract</td></tr>
+    <tr><td>Defragment all disks</td><td>VirtualMachine.Interact.DefragmentAllDisks</td></tr>
     <tr><td>Device connection</td><td>VirtualMachine.Interact.DeviceConnection</td></tr>
     <tr><td>Guest operating system management by VIX API</td><td>VirtualMachine.Interact.GuestControl</td></tr>
     <tr><td>Power off</td><td>VirtualMachine.Interact.PowerOff</td></tr>
@@ -216,12 +228,12 @@ When using `vAppImport` to clone a VM, BOSH requires the resource migration priv
       <th>Privilege (UI)</th>
       <th>Privilege (API)</th>
     </tr>
-    <tr><td>Create new VM from existing</td><td>VirtualMachine.Inventory.CreateFromExisting</td></tr>
-    <tr><td>Create new VM</td><td>VirtualMachine.Inventory.Create</td></tr>
+    <tr><td>Create from existing</td><td>VirtualMachine.Inventory.CreateFromExisting</td></tr>
+    <tr><td>Create new</td><td>VirtualMachine.Inventory.Create</td></tr>
     <tr><td>Move</td><td>VirtualMachine.Inventory.Move</td></tr>
-    <tr><td>Add a VM to a vCenter Server or host inventory</td><td>VirtualMachine.Inventory.Register</td></tr>
+    <tr><td>Register</td><td>VirtualMachine.Inventory.Register</td></tr>
     <tr><td>Remove a VM</td><td>VirtualMachine.Inventory.Delete</td></tr>
-    <tr><td>Unregister a VM from a vCenter Server or host inventory</td><td>VirtualMachine.Inventory.Unregister</td></tr>
+    <tr><td>Unregister</td><td>VirtualMachine.Inventory.Unregister</td></tr>
 </table>
 
 #### <a id="provisioning"></a>Provisioning


### PR DESCRIPTION
This adds a few new permissions required by PAS 2.7+ installed on vSphere 6.7:
- Datastore.FileManagement
- StorageProfile.Update
- StorageProfile.View

And updates a few other UI privilege descriptions to match vSphere 6.7.