### PR TITLE
Increasing Service Principal permissions to Owner

### DIFF
--- a/azure/prepare-azure-terraform.html.md.erb
+++ b/azure/prepare-azure-terraform.html.md.erb
@@ -162,11 +162,11 @@ This topic describes how to prepare Azure to deploy Pivotal Operations Manager. 
     }
     </pre>
 
-1. You must have the Contributor role on your service principal to deploy Ops Manager to Azure. To assign the Contributor role on your service principal, run:
+1. You must have the Owner role on your service principal to deploy Ops Manager to Azure. To assign the Owner role on your service principal, run:
 
     ```
     az role assignment create --assignee "SERVICE-PRINCIPAL-NAME" \
-    --role "Contributor" --scope /subscriptions/SUBSCRIPTION-ID
+    --role "Owner" --scope /subscriptions/SUBSCRIPTION-ID
     ```
     Where:
     * `SERVICE-PRINCIPAL-NAME` is any value of `servicePrincipalNames` from the output above, such as `YOUR-APP-ID`.
@@ -176,7 +176,7 @@ This topic describes how to prepare Azure to deploy Pivotal Operations Manager. 
     <pre class="terminal">
     $ az role assignment create \
     --assignee "5c552e8f-b977-45f5-a50b-981cfe17cb9d" \
-    --role "Contributor" \
+    --role "Owner" \
     --scope /subscriptions/87654321-1234-5678-1234-567891234567
     </pre>
     <p class="note"><strong>Note:</strong> If you need to use multiple resource groups for your deployment on Azure, you can define custom roles for your Service Principal. These roles allow BOSH to deploy to pre-existing network resources outside of the resource group.</p>
@@ -201,7 +201,7 @@ This topic describes how to prepare Azure to deploy Pivotal Operations Manager. 
           "principalId": "cc13c685-4c3b-461e-ae96-7a0563960b83",
           "principalName": "http<span>:</span>//BOSHAzureCPI",
           "roleDefinitionId": "/subscriptions/995b7eed-77ef-45ff-a5c9-1a405ffb8243/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
-          "roleDefinitionName": "Contributor",
+          "roleDefinitionName": "Owner",
           "scope": "/subscriptions/995b7eed-77ef-45ff-a5c9-1a405ffb8243"
         },
         "type": "Microsoft.Authorization/roleAssignments"


### PR DESCRIPTION
I am currently working with a customer (MTN Group), and we've discovered a permissions issue in Azure that requires the Service Principal to have the "Owner" role, instead of "Contributor".

We are following the instructions for deploying Ops Manager 2.8 with Terraform.  It seems if you are using the PKS Terraform code, it tries to create two Azure Role definitions for the PKS worker and master VMs, respectively.  According to the [Azure docs](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles#contributor), Contributors are not allowed to modify roles, only Owners can do this.

You can replicate this permissions issue by following the [current version](https://docs.pivotal.io/platform/ops-manager/2-6/azure/prepare-azure-terraform.html) of this document to create an Azure Service Principal, then running the latest terraforming-azure code for PKS, which is located here: https://github.com/pivotal-cf/terraforming-azure/tree/master.

As far as I know, this is only an issue for the users of the PKS Terraform code, not PAS.