### PR TITLE
Removing the flag for public blob access in stemcell container

### DIFF
--- a/azure/deploy-manual.html.md.erb
+++ b/azure/deploy-manual.html.md.erb
@@ -187,7 +187,7 @@ To create storage accounts for BOSH and your deployment, do the following:
     --connection-string $CONNECTION\_STRING
     $ az storage container create --name bosh \
     --connection-string $CONNECTION\_STRING
-    $ az storage container create --name stemcell --public-access blob \
+    $ az storage container create --name stemcell \
     --connection-string $CONNECTION\_STRING
     </pre>
 


### PR DESCRIPTION
Removing the flag for public blob access in stemcell container - no longer required (private works)