### PR TITLE
 Improve help text of "Recreate All VMs" checkbox

### DIFF
--- a/common/_director-config.html.md.erb
+++ b/common/_director-config.html.md.erb
@@ -43,7 +43,7 @@ To configure the **Director Config** pane:
 1. Select **Enable Post Deploy Scripts** to run a post-deploy script after deployment. This script allows the job to execute additional commands against a deployment.
     <p class="note"><strong>Note:</strong> If you intend to install <%= vars.k8s_runtime_full %> (<%= vars.k8s_runtime_abbr %>), you must enable post-deploy scripts.</p>
 
-1. Select **Recreate VMs deployed by the BOSH Director** to force BOSH to recreate BOSH-deployed VMs on the next deploy. This process does not destroy any persistent disk data.
+1. Select **Recreate VMs deployed by the BOSH Director** to force BOSH to recreate BOSH-deployed VMs on the next deploy. This process does not recreate the BOSH Director. Also, this process does not destroy any persistent disk data.
 
 1. Select **Recreate BOSH Director VMs** to force the BOSH Director VM to be recreated on the next deploy. This process does not destroy any persistent disk data.
 


### PR DESCRIPTION
- This checkbox does not re-create the BOSH director VM, which many
customers find surprising. This checkbox was renamed in 2.9 to be more
accurate.