### PR TITLE
Add note about metrics server issue being resolved

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -192,3 +192,5 @@ Required property 'networks' was not specified in object ({"vm_extensions"=>[{"c
 The cause of this upgrade failure is the presence of a tile, such as any version of Tanzu Kubernetes Grid Integrated Edition (TKGI), that is incompatible with Ops Manager v2.10 due to its default `metrics-server` enablement.
 
 To workaround this issue, see the [BOSH Director fails with non-running job during upgrade to Ops Manager 2.10](https://community.pivotal.io/s/article/OM-2-10-Bosh-Director-fails-to-deploy) Knowledge Base article.
+
+This issue is resolved in Ops Manager v2.10.1.


### PR DESCRIPTION
Ops Manager 2.10.1 resolves the issue caused by the metrics server.