### PR TITLE
AWS operators can specify the credentials source

### DIFF
--- a/common/_blobstore-location.html.md.erb
+++ b/common/_blobstore-location.html.md.erb
@@ -23,11 +23,10 @@ Select a **Blobstore Location** to either configure the blobstore as an internal
       1. **URL Style:** Select either path-style or domain-style to specify the URL style for the S3-compatible blobstore. By default, the blobstore uses domain-style URLs.
           <p class="note warning"><strong>Warning:</strong> AWS ends support for path-style URLs for all S3 buckets created after September 30, 2020. For more information, see <a href="https://docs.pivotal.io/platform/2-9/release-notes/opsmanager-rn.html#domain-style">Support for Virtual-Hosted-Style URLs for AWS S3 Blobstores</a>.</p>
       <% if current_page.data.iaas == "AWS" %>
-      1. **Credentials Source**
-        1. **Static Credentials**
-          1. **Access Key** and **Secret Key:** Enter the keys you generated when creating your S3 bucket.
-        1. **IAM Profile**
-          1. Use the IAM profile associated with the BOSH Director
+      1. **Credentials Source:**
+      Input your credentials from the following sources.
+          - **Static Credentials:** In **Access Key** and **Secret Key**, enter the keys you generated when creating your S3 bucket.
+          - **IAM Profile:** Use the IAM profile associated with the BOSH Director.
       <% else %>
       1. **Access Key** and **Secret Key:** Enter the keys you generated when creating your S3 bucket.
       <% end %>

--- a/common/_blobstore-location.html.md.erb
+++ b/common/_blobstore-location.html.md.erb
@@ -22,7 +22,15 @@ Select a **Blobstore Location** to either configure the blobstore as an internal
       1. **Bucket Name:** Enter the name of the S3 bucket.
       1. **URL Style:** Select either path-style or domain-style to specify the URL style for the S3-compatible blobstore. By default, the blobstore uses domain-style URLs.
           <p class="note warning"><strong>Warning:</strong> AWS ends support for path-style URLs for all S3 buckets created after September 30, 2020. For more information, see <a href="https://docs.pivotal.io/platform/2-9/release-notes/opsmanager-rn.html#domain-style">Support for Virtual-Hosted-Style URLs for AWS S3 Blobstores</a>.</p>
+      <% if current_page.data.iaas == "AWS" %>
+      1. **Credentials Source**
+        1. **Static Credentials**
+          1. **Access Key** and **Secret Key:** Enter the keys you generated when creating your S3 bucket.
+        1. **IAM Profile**
+          1. Use the IAM profile associated with the BOSH Director
+      <% else %>
       1. **Access Key** and **Secret Key:** Enter the keys you generated when creating your S3 bucket.
+      <% end %>
       1. **Enable signed URLs:** Select this checkbox to configure BOSH VMs to generate short-lived, pre-signed URLs for communication between the BOSH Agent and blobstore. If you enable this feature, BOSH Agents do not use credentials to communicate with the blobstore, and VM disks do not store blobstore credentials.
           <p class="note"><strong>Note:</strong> This feature is experimental and only available for BOSH VMs that use Xenial stemcell line 621 or later.</p>
       1. Select **V2 Signature** or **V4 Signature**. If you select **V4 Signature**, enter your **Region**.


### PR DESCRIPTION
These credentials are used to access their s3-compatible blobstore