### PR TITLE
Explains that maestro regenerate ca also add transitional flags

### DIFF
--- a/security/pcf-infrastructure/advanced-certificate-rotation.html.md.erb
+++ b/security/pcf-infrastructure/advanced-certificate-rotation.html.md.erb
@@ -98,9 +98,9 @@ The process for rotating the Services TLS CA requires additional steps to ensure
 
 To rotate all CAs and leaf certificates in CredHub:
 
-1. Regenerate all CAs. This marks the latest version of each CA as transitional, creates a new version of every CA, and
-indicates that the latest version is inactive so that all leaf certificates trust the new CA. Run:
-
+1. Regenerate all CAs. This creates a new version of every CA and marks these new CA versions as transitional.
+The transitional status indicates that these new CA versions will not yet sign any leaf certificates, though they
+will be trusted by clients. Run:
     ```
     maestro regenerate ca --all
     ```

--- a/security/pcf-infrastructure/getting-started-with-maestro-cli.html.md.erb
+++ b/security/pcf-infrastructure/getting-started-with-maestro-cli.html.md.erb
@@ -103,7 +103,8 @@ You can use the following flags with `maestro topology`:
 
 #### <a id='regenerate-ca'></a> maestro regenerate ca
 
-`maestro regenerate ca` regenerates actively deployed CAs.
+`maestro regenerate ca` regenerates actively deployed CAs and adds transitional flags to these new CA versions.
+The transitional status indicates that these new CA versions will not yet sign any leaf certificates, though they will be trusted by clients.
 
 You can use the following flags with `maestro regenerate ca`:
 


### PR DESCRIPTION
- `maestro update-transitional latest` step is removed and merged
into `maestro regenerate ca` for Maestro v8+
- improve language on what "transitional" means

Hello docs team, this fix applies to OpsMan 2.11 (which we assume is the master branch, which this PR handles) and also OpsMan 2.10 (could you handle merging into OpsMan 2.10? Or do you prefer us starting a new separate PR?)

Co-authored-by: Aidan Obley <aobley@vmware.com>