### PR TITLE
Update product names in "CredHub Maestro Tile Compatibility"

### DIFF
--- a/security/pcf-infrastructure/maestro-tile-compatibility.html.md.erb
+++ b/security/pcf-infrastructure/maestro-tile-compatibility.html.md.erb
@@ -23,73 +23,73 @@ For more information about CredHub Maestro, see [Getting Started with CredHub Ma
     <td>pivotal-container-service</td>
     <td><em>n/a</em></td>
     <td>No</td>
-    <td>You cannot use CredHub Maestro to rotate certificates for <%= vars.k8s_runtime_abbr %>. However, if a multi-runtime <%= vars.platform_name %> deployment includes <%= vars.k8s_runtime_abbr %> v1.8 or earlier, you must use CredHub Maestro to rotate CredHub-managed certificates for all other runtimes. For more information, see <a href="advanced-certificate-rotation.html">Advanced Certificate Rotation with CredHub Maestro</a>.</td>
+    <td>You cannot use CredHub Maestro to rotate certificates for <%= vars.k8s_runtime_abbr %> v1.8 and earlier. However, if a multi-runtime <%= vars.platform_name %> deployment includes <%= vars.k8s_runtime_abbr %> v1.8 or earlier, you must use CredHub Maestro to rotate CredHub-managed certificates for all other runtimes. For more information, see <a href="advanced-certificate-rotation.html#when-to-use">When to Use CredHub Maestro for Certificate Rotation</a> in <em>Advanced Certificate Rotation with CredHub Maestro</em>.</td>
   </tr>
   <tr>
-    <td>File Integrity Monitoring Add-on for PCF</td>
+    <td>File Integrity Monitoring</td>
     <td>p-fim</td>
     <td>2.0.0</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>IPsec Add-on for PCF</td>
+    <td>IPsec</td>
     <td>ipsec</td>
     <td><em>n/a</em></td>
     <td>No</td>
-    <td>IPsec uses its own rotation method. For more information, see <a href="https://docs.pivotal.io/addon-ipsec/1-9/credentials.html">Rotating Active IPsec Certificates</a> in the IPsec Add-On for PCF documentation.</td>
+    <td>IPsec uses its own rotation method. For more information, see <a href="https://docs.pivotal.io/addon-ipsec/1-9/credentials.html">Rotating Active IPsec Certificates</a> in the IPsec documentation.</td>
   </tr>
   <tr>
     <td>Metric Store (alpha)</td>
     <td>p-metric-store</td>
-    <td><em>n/a</em></td>
-    <td>No</td>
+    <td>1.3.1</td>
+    <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Metrics Forwarder for PCF</td>
+    <td>Metrics Forwarder</td>
     <td>p-metrics-forwarder</td>
     <td>1.11.4-build.20</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Pivotal Cloud Foundry Metrics</td>
+    <td>App Metrics</td>
     <td>apmPostgress</td>
     <td>1.6.2-build.1</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Monitoring Indicator Protocol for PCF</td>
+    <td>Monitoring Indicator Protocol</td>
     <td>p-monitoring-indicator-protocol</td>
     <td>1.0.0-beta4.1</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>MySQL for PCF v2</td>
+    <td>MySQL for VMware Tanzu</td>
     <td>pivotal-mysql</td>
     <td>2.8</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>PCF Event Alerts</td>
+    <td>Event Alerts</td>
     <td>p-event-alerts</td>
     <td>2.9.1-build.1</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Pivotal Anti-Virus</td>
+    <td>Anti-Virus</td>
     <td>p-antivirus</td>
     <td>2.2.2</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Pivotal Anti-Virus Mirror</td>
+    <td>Anti-Virus Mirror</td>
     <td>p-antivirus-mirror</td>
     <td>2.2.2</td>
     <td>Yes</td>
@@ -98,7 +98,7 @@ For more information about CredHub Maestro, see [Getting Started with CredHub Ma
   <tr>
     <td><%= vars.app_runtime_full %></td>
     <td>cf</td>
-    <td>2.8.2-vuild.11</td>
+    <td>2.8.2-build.11</td>
     <td>Yes</td>
     <td></td>
   </tr>
@@ -110,21 +110,21 @@ For more information about CredHub Maestro, see [Getting Started with CredHub Ma
     <td></td>
   </tr>
   <tr>
-    <td>Pivotal Cloud Cache</td>
+    <td>VMware Tanzu Gemfire</td>
     <td>p-cloudcache</td>
     <td>1.11</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Pivotal Compliance Scanner</td>
+    <td>Compliance Scanner</td>
     <td>p-compliance-scanner</td>
     <td>1.2.16</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Pivotal Healthwatch</td>
+    <td>Healthwatch</td>
     <td>p-healthwatch</td>
     <td>1.8.0-build.66</td>
     <td>Yes</td>
@@ -138,28 +138,28 @@ For more information about CredHub Maestro, see [Getting Started with CredHub Ma
     <td></td>
   </tr>
   <tr>
-    <td>Pivotal Push Notification Service</td>
+    <td>Push Notification</td>
     <td>p-push-notifications</td>
     <td>1.10.6-build.6</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Pivotal Telemetry</td>
+    <td>Telemetry Collector</td>
     <td>pivotal-telemetry-om</td>
     <td><em>n/a</em></td>
     <td>No</td>
     <td></td>
   </tr>
   <tr>
-    <td>RabbitMQ for PCF</td>
+    <td>RabbitMQ for VMware Tanzu [VMs]</td>
     <td>p-rabbitmq</td>
     <td>1.20</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Redis for PCF</td>
+    <td>Redis for VMware Tanzu</td>
     <td>p-redis</td>
     <td>2.4</td>
     <td>Yes</td>
@@ -173,7 +173,7 @@ For more information about CredHub Maestro, see [Getting Started with CredHub Ma
     <td></td>
   </tr>
   <tr>
-    <td>Reliability View for PCF (Beta)</td>
+    <td>Reliability View</td>
     <td>p-reliability-view</td>
     <td>0.4.0-build.124</td>
     <td>Yes</td>
@@ -187,7 +187,7 @@ For more information about CredHub Maestro, see [Getting Started with CredHub Ma
     <td></td>
   </tr>
   <tr>
-    <td>Scheduler for PCF</td>
+    <td>Scheduler</td>
     <td>p-scheduler</td>
     <td>1.2.30-build.1</td>
     <td>Yes</td>
@@ -201,8 +201,8 @@ For more information about CredHub Maestro, see [Getting Started with CredHub Ma
     <td></td>
   </tr>
   <tr>
-    <td>Single Sign-On for PCF</td>
-    <td>Pivotal_Single_Sign-On_Service</td>
+    <td>Single Sign-On</td>
+    <td>pivotal_single_sign-on_service</td>
     <td>1.11.0</td>
     <td>Yes</td>
     <td></td>
@@ -215,14 +215,14 @@ For more information about CredHub Maestro, see [Getting Started with CredHub Ma
     <td></td>
   </tr>
   <tr>
-    <td>Spring Cloud Data Flow for PCF</td>
+    <td>Spring Cloud Data Flow for VMware Tanzu</td>
     <td>p-dataflow</td>
     <td>1.6.6</td>
     <td>Yes</td>
     <td></td>
   </tr>
   <tr>
-    <td>Spring Cloud Services for PCF</td>
+    <td>Spring Cloud Services for VMware Tanzu</td>
     <td>p_spring-cloud-services</td>
     <td>3.1.5</td>
     <td>Yes</td>
@@ -236,7 +236,7 @@ For more information about CredHub Maestro, see [Getting Started with CredHub Ma
     <td></td>
   </tr>
   <tr>
-    <td>VMware NSX-T Container Plug-in for PCF</td>
+    <td>VMware NSX-T Container Plug-in</td>
     <td>VMware-NSX-T</td>
     <td>2.5.1</td>
     <td>Yes</td>


### PR DESCRIPTION
- update product names according to the 2.9 docs, which has already
been updated to reflect the new product names
- fix typo

The product name for TAS is still outdated. It still says "Pivotal Application Service" in the live docs. But this product name, unlike the ones I have changed in this PR, is linked to this globally-used var: `vars.app_runtime_full`. 
So I left it alone for the docs team to decide when is the best time change vars globally. 

