### PR TITLE
Update _director-config.html.md.erb

### DIFF
--- a/common/_director-config.html.md.erb
+++ b/common/_director-config.html.md.erb
@@ -25,8 +25,7 @@ To configure the **Director Config** pane:
 
 <%# For AWS: %>
 <% elsif current_page.data.iaas == "AWS" %>
-1. Enter at least two of the following NTP servers in the **NTP Servers (comma delimited)** field, separated by a comma: `0.amazon.pool.ntp.org,1.amazon.pool.ntp.org,2.amazon.pool.ntp.org,3.amazon.pool.ntp.org`.
-
+1. Enter at least two of the following NTP servers in the **NTP Servers (comma delimited)** field, separated by a comma: `0.amazon.pool.ntp.org,1.amazon.pool.ntp.org,2.amazon.pool.ntp.org,3.amazon.pool.ntp.org` However if your AWS environment is air gapped, consider using [Amazon's Time Sync Service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html#configure-amazon-time-service) which has a dedicated IP that does not require access to the internet nor configuration changes to your security group rules or your network ACL rules to access. 
 
 <%# For other IaaSes such as vSphere and Azure: %>
 <% else %>


### PR DESCRIPTION
In case 261950 we discovered time drift because their env was airgapped and couldn't reach the ntp servers in our documentation. They used the dedicated IP for Amazon's Time Sync Service (which is reachable by all instances even in airgapped envs) and it worked.