### PR TITLE
Remove duplicate breaking change for OM 2.10

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -307,16 +307,6 @@ This command performs both actions, while previous versions of CredHub Maestro u
 
 For information about rotating CAs and certificates using CredHub Maestro, see [Advanced Certificate Rotation with CredHub Maestro](https://docs.pivotal.io/platform/2-10/security/pcf-infrastructure/advanced-certificate-rotation.html).
 
-### <a id='metrics-server-upgrade'></a> Metrics Server Configuration Causes BOSH Director Deployment to Fail During Upgrade
-
-During an upgrade to Ops Manager v2.10, the BOSH Director deployment and
-subsequent upgrade may fail due to the default enablement of the `metrics-server` job.
-
-The cause of this upgrade failure is the presence of a tile, such as any version of Tanzu Kubernetes Grid Integrated Edition (TKGI), that is incompatible with Ops Manager v2.10 due to its default `metrics-server` enablement.
-
-To work around this issue, see the [BOSH Director fails with non-running job during upgrade to Ops Manager 2.10](https://community.pivotal.io/s/article/OM-2-10-Bosh-Director-fails-to-deploy) Knowledge Base article.
-
-
 ## <a id='known-issues'></a> Known Issues
 
 <%= vars.ops_manager %> v2.10 includes the following known issue:


### PR DESCRIPTION
The metrics server issue listed under "breaking changes" is already listed under Known Issues, and has been fixed since 2.10.1.