### PR TITLE
Remove old command

### DIFF
--- a/security/pcf-infrastructure/advanced-certificate-rotation.html.md.erb
+++ b/security/pcf-infrastructure/advanced-certificate-rotation.html.md.erb
@@ -189,12 +189,8 @@ To rotate a single CA and its leaf certificates:
     Where `CA-NAME` is the name of the CA you want to rotate.
     <p class="note"><strong>Note:</strong> The CA name you provide must be the full path to the credential.</p>
 
-1. Mark the latest version of the single CA as transitional by running:
-
-    ```
-    maestro update-transitional latest --name "CA-NAME"
-    ```
-    Where `CA-NAME` is the name of the CA you want to mark as transitional.
+    <p class="note"><strong>Note:</strong> As of TAS 2.10, this command
+    also does what the `maestro update-transitional latest` used to do</p>
 
 1. Redeploy all deployments that use the CA.
 


### PR DESCRIPTION
I tried to add a note to the `regenerate` command to help the user who was used to opsman 2.9 understand what happened to the commands he used to run. Let me know if you don't think it's good.

* the `maestro update-transitional latest` command no longer exists as
  of TAS 2.10
  (https://docs.pivotal.io/ops-manager/2-10/release-notes.html#credhub-regenerate).