### PR TITLE
Security group rules default change

### DIFF
--- a/aws/prepare-env-manual.html.md.erb
+++ b/aws/prepare-env-manual.html.md.erb
@@ -283,8 +283,8 @@ Perform the following steps to create an Amazon Identity and Access Management (
 <tr>
   <td>All traffic</td>
   <td>All</td>
-  <td>0 - 65535</td>
-  <td>Custom IP</td>
+  <td>All</td>
+  <td>All</td>
   <td>10.0.0.0/16</td>
 </tr>
 </table>


### PR DESCRIPTION
When you click "all traffic" it defaults to "All" & " All" instead of the prior defaults of 0 - 65535 Custom IP . This is not something you can change to reflect the prior version so we must update the docs to match what will be displayed, all/all