### PR TITLE
Default vm size change

### DIFF
--- a/aws/deploy-manual.html.md.erb
+++ b/aws/deploy-manual.html.md.erb
@@ -43,7 +43,7 @@ To launch an Amazon Machine Image (AMI) for <%= vars.ops_manager %>, do the foll
 
 1. Select the row that lists your <%= vars.ops_manager %> AMI and click **Launch**.
 
-1. Choose **m3.large** for your instance type and click **Next: Configure Instance Details**.
+1. Choose **m4.large** for your instance type and click **Next: Configure Instance Details**.
 
     <%= image_tag("../common/images/pcfaws/aws_ami_m3large.png") %>
 


### PR DESCRIPTION
The lowest available size at this time is m4. Same cpu / mem as m3, just amazon rolling versions.