### PR TITLE
Update current defaults

### DIFF
--- a/aws/deploy-manual.html.md.erb
+++ b/aws/deploy-manual.html.md.erb
@@ -57,7 +57,7 @@ To launch an Amazon Machine Image (AMI) for <%= vars.ops_manager %>, do the foll
     <%= image_tag("../common/images/pcfaws/pcf_aws_configure_instance.png") %>
 
 1. Click **Next: Add Storage** and adjust the **Size (GiB)** value.
-The default persistent disk value is 50&nbsp;GB. <%= vars.company_name %> recommends increasing this value to a minimum of 100&nbsp;GB.
+The default persistent disk value is 8&nbsp;GB. <%= vars.company_name %> recommends increasing this value to a minimum of 100&nbsp;GB.
 
     <%= image_tag("../common/images/pcfaws/pcf_aws_add_storage.png") %>
 


### PR DESCRIPTION
The default listed on the page for creating the persistent disk now lists 8gb as the default.