### PR TITLE
Mention the stemcell re-upload is required after upgrade

### DIFF
--- a/opsguide/managing-stemcells.html.md.erb
+++ b/opsguide/managing-stemcells.html.md.erb
@@ -41,7 +41,7 @@ To import and stage a stemcell:
 
 If you have uploaded multiple versions of a stemcell, you can use the dropdown in the **Staged** column to choose which version to use.
 
-You can choose a different version until you deploy. After deployment, older stemcell versions are no longer available.
+You can choose a different version until you deploy. After deployment, older stemcell versions are no longer available. After upgrading Ops Manager if you want to use a stemcell that was uploaded prior to upgrade then you need to re-upload it.
 
 ![The dropdown for a stemcell is displayed in the Staged column. Three versions are available.](./images/opsman-view-available-stemcells.png)
 


### PR DESCRIPTION
Since we have more customers only upgrading Ops Manager, and keeping their tile versions the same, they are running into problems where stemcells and tiles are missing from ops manager.

Update the docs to make it clear that after upgrade, they need to upload their current stemcells and tiles.

[#176465133(https://www.pivotaltracker.com/story/show/176465133)