### PR TITLE
Add a warning that UAA users are deleted if UAA settings are updated.

### DIFF
--- a/install/opsman-users.html.md.erb
+++ b/install/opsman-users.html.md.erb
@@ -14,6 +14,8 @@ Manager automation.
 
 When Ops Manager boots for the first time, you create an admin user. However, you do not create additional users through the Ops Manager web interface. If you want to create additional users who can log into Ops Manager, you must use the UAA API, either through `curl` or the UAA Command Line Client (UAAC).
 
+<p class="note"><strong>Note:</strong> Users that are created this way are not going to persist if UAA authentication settings change.</p>
+
 Users are not the only type of account you can create for Ops Manager. You can also create client accounts, which connect automation tools and scripts to Ops Manager. Pivotal recommends using clients to handle automated tasks.
 
 Client accounts are not bound to the same authentication protocols as user accounts. A user account that controls automated components can cause those components to fail if the account experiences inconsistent availability due to permission or authentication issues.

--- a/opsguide/config-rbac.html.md.erb
+++ b/opsguide/config-rbac.html.md.erb
@@ -71,7 +71,7 @@ If your organization has operators who are devoted to managing certain services 
 
 If you upgrade from an older <%= vars.ops_manager %> instance, you must enable RBAC and assign roles to users before they can access <%= vars.ops_manager %>. If you do not assign any roles to a user, they cannot log in to <%= vars.ops_manager %>.
 
-<p class="note warning"><strong>Warning:</strong> Do not assign roles before you enable RBAC.</p>
+<p class="note warning"><strong>Warning:</strong> Do not assign roles before you enable RBAC. Changing UAA authentication settings causes the roles deletion.</p>
 
 ### <a id="enable-internal"></a> Enable RBAC with Internal Authentication
 


### PR DESCRIPTION
Whenever UAA authentication settings are updated Ops Manager deletes the database. Users that are manually created are going to be deleted.