### PR TITLE
Add note about External MySQL Database setting

### DIFF
--- a/common/_director-database-location.html.md.erb
+++ b/common/_director-database-location.html.md.erb
@@ -10,6 +10,7 @@ This partial is called from `_director-config.html.md.erb`.
 <%# For GCP Terraform config topic only: %>
 <% if current_page.data.iaas == "GCP" and current_page.data.install_type == "terraform" %>
 For **Database Location**, if you configured your `terraform.tfvars` file to create an external database for <%= vars.ops_manager %>, select **External MySQL Database** and complete the fields below. Otherwise, select **Internal**.
+<p class="note"><strong>Note:</strong> Use of an External MySQL Database only applies to the BOSH Director. UAA and CredHub will not use these settings and will continue to use the Postgres database colocated with the BOSH Director.</p>
 <p class="note warning"><strong>Warning:</strong> After you deploy the BOSH Director, you cannot change the <b>Database Location</b> from an <b>External MySQL Database</b> to an <b>Internal</b> database or from an <b>Internal</b> database to an <b>External MySQL Database</b>.</p>
     * **Host**: Enter the value of `sql_db_ip` from your Terraform output.
     * **Port**: Enter `3306`.
@@ -28,6 +29,7 @@ In addition, if you selected **External MySQL Database**, you can fill out the f
 <%# For GCP Manual config topic only: %>
 <% elsif current_page.data.iaas == "GCP" %>
 For **Database Location**, if you configured an external MySQL database such as Cloud SQL, select **External MySQL Database** and complete the fields below. Otherwise, select **Internal**. For more information about creating a Cloud SQL instance, see [Quickstart for Cloud SQL for MySQL](https://cloud.google.com/sql/docs/mysql/quickstart) in the Google Cloud documentation.
+<p class="note"><strong>Note:</strong> Use of an External MySQL Database only applies to the BOSH Director. UAA and CredHub will not use these settings and will continue to use the Postgres database colocated with the BOSH Director.</p>
 <p class="note warning"><strong>Warning:</strong> After you deploy the BOSH Director, you cannot change the <b>Database Location</b> from an <b>External MySQL Database</b> to an <b>Internal</b> database or from an <b>Internal</b> database to an <b>External MySQL Database</b>.</p>
     * **Host:** Enter the value of your host.
     * **Port:** Enter your port number. For example, `3306`.
@@ -44,6 +46,7 @@ In addition, if you selected the **Enable TLS for Director Database** checkbox, 
 <%# For AWS Terraform config topic only: %>
 <% elsif current_page.data.iaas == "AWS" and current_page.data.install_type == "terraform" %>
 For **Database Location**, if you choose to configure an external MySQL database with Amazon Relational Database Service (RDS) or another service, select **External MySQL Database** and complete the fields below. Otherwise, select **Internal**. For more information about creating a RDS MySQL instance, see [Creating a MySQL DB Instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.MySQL.html#CHAP_GettingStarted.Creating.MySQL) in the AWS documentation.
+<p class="note"><strong>Note:</strong> Use of an External MySQL Database only applies to the BOSH Director. UAA and CredHub will not use these settings and will continue to use the Postgres database colocated with the BOSH Director.</p>
 <p class="note warning"><strong>Warning:</strong> After you deploy the BOSH Director, you cannot change the <b>Database Location</b> from an <b>External MySQL Database</b> to an <b>Internal</b> database or from an <b>Internal</b> database to an <b>External MySQL Database</b>.</p>
     * **Host**: Enter the value of your host.
     * **Port**: Enter your port number. For example, `3306`.
@@ -61,6 +64,8 @@ In addition, if you selected the **Enable TLS for Director Database** checkbox, 
 <%# For AWS Manual config topic only: %>
 <% elsif current_page.data.iaas == "AWS" %>
 For **Database Location**, select **External MySQL Database** and complete the following steps:
+    <p class="note"><strong>Note:</strong> Use of an External MySQL Database only applies to the BOSH Director. UAA and CredHub will not use these settings and will continue to use the Postgres database colocated with the BOSH Director.</p>
+    <p class="note warning"><strong>Warning:</strong> After you deploy the BOSH Director, you cannot change the <b>Database Location</b> from an <b>External MySQL Database</b> to an <b>Internal</b> database or from an <b>Internal</b> database to an <b>External MySQL Database</b>.</p>
     <%= image_tag("../common/images/director_database.png", :alt=> "At the top of the image are the words 'Database Location', underneath which are two options: one selected radio button labeled 'Internal', and one radio button labeled 'External MySQL Database'. Below these are five text fields labeled, from top to bottom, 'Host', 'Port', 'Username', 'Password', and 'Database'. All have red asterisks, to denote that they are required fields when 'External MySQL Database' is selected.") %>
     * From the AWS Console, navigate to the RDS Dashboard.
     * Select **Instances**, then click the arrow to the left of your instance and select the second icon to display the **Details** information.
@@ -104,6 +109,7 @@ For **Database Location**, select **Internal**.
 <%# For all other IaaSes such as OpenStack, vSphere and manual Azure: %>
 <% else %>
 Select a **Database Location**. By default, <%= vars.ops_manager %> deploys and manages an **Internal** database for you. If you choose to use an **External MySQL Database**, complete the associated fields with information obtained from your external MySQL Database provider: **Host**, **Port**, **Username**, **Password**, and **Database**.
+<p class="note"><strong>Note:</strong> Use of an External MySQL Database only applies to the BOSH Director. UAA and CredHub will not use these settings and will continue to use the Postgres database colocated with the BOSH Director.</p>
 <p class="note warning"><strong>Warning:</strong> After you deploy the BOSH Director, you cannot change the <b>Database Location</b> from an <b>External MySQL Database</b> to an <b>Internal</b> database or from an <b>Internal</b> database to an <b>External MySQL Database</b>.</p>
     <%= image_tag("../common/images/director_database.png", :alt=> "At the top of the image are the words 'Database Location', underneath which are two options: one selected radio button labeled 'Internal', and one radio button labeled 'External MySQL Database'. Below these are five text fields labeled, from top to bottom, 'Host', 'Port', 'Username', 'Password', and 'Database'. All have red asterisks, to denote that they are required fields when 'External MySQL Database' is selected.") %><br>
     In addition, if you selected the **Enable TLS for Director Database** checkbox, you can complete the following optional fields:


### PR DESCRIPTION
The External MySQL Database setting in Ops Manager only applies to the BOSH Director's database. The UAA and CredHub instances deployed on the BOSH Director VM always use the Postgres database on the BOSH Director VM.

Also adds the warning note about database location being locked after deploying the BOSH Director to IaaSes that were missing this warning.