### PR TITLE
Document BOSH DNS regeneration w/ SAN

### DIFF
--- a/jump-upgrades.html.md.erb
+++ b/jump-upgrades.html.md.erb
@@ -36,6 +36,13 @@ an upgrade path for your product tiles, see the [Upgrade Planner](https://upgrad
 
 * You have installed Trusty stemcell 3541 or later.
 
+## <a id="bosh-dns-migration"></a> BOSH DNS Certificates Regeneration
+
+Starting in <%= vars.ops_manager %> v2.10.9 and later, BOSH DNS leaf certificates are generated to include the subject alternative name (SAN) field. The inclusion of the SAN field was made a requirement in Go 1.15 and later, which many components deployed by Ops Manager such as BOSH DNS require.
+
+Upon upgrading to 2.10.9 and later, the BOSH DNS leaf certificates will be automatically regenerated to include the SAN field on the next Apply Changes. You must redeploy all tiles and upgrade all service instances to ensure the new version of the BOSH DNS leaf certificates are distributed to all VMs. This automatic regeneration is also done on <%= vars.ops_manager %> v2.7.30, v2.8.16, and v2.9.18.
+
+<p class="note warning"><strong>Warning:</strong> A future patch version of <%= vars.ops_manager %> v2.10 will require that BOSH DNS certificates have been redeployed with a SAN. If you do not redeploy all tiles and upgrade all service instances after the BOSH DNS leaf certifcates have been regenerated, you may experience communication errors between system components, deployed applications, and service instances, which could result in downtime.</p>
 
 ## <a id="jump-upgrade"></a> Jump Upgrade
 


### PR DESCRIPTION
Starting in Ops Manager v2.10.9, customers upgrading from previous versions will automatically have their BOSH DNS leaf certificates regenerated / rotated in order to add a SAN field that will be required in future versions of BOSH DNS.

Do not merge yet, as the affected versions are not released yet.