### PR TITLE
Fix typo - from "doesx" to "does"

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -25,7 +25,7 @@ on the Cloud Foundry website.
 
 **Release Date:** April 27, 2021
 
-- **[Bug Fix]** <%= vars.ops_manager %> doesx not overwrite UAAC
+- **[Bug Fix]** <%= vars.ops_manager %> does not overwrite UAAC
 - **[Bug Fix]]** Regenerating leaf certificates succeed when CredHub server certificate is expired
 
 


### PR DESCRIPTION
Removed unexpected "x" from the word "doesx"