### PR TITLE
Fix link to API docs

### DIFF
--- a/install/ops-man-api.html.md.erb
+++ b/install/ops-man-api.html.md.erb
@@ -13,7 +13,7 @@ The Ops Manager API controls the Ops Manager VM directly, bypassing the Ops Mana
 Platform operators use the Ops Manager API to automate deployments, retrieve and manage credentials, and otherwise work with Ops Manager.
 Tile Developers use the Ops Manager API to test and debug <%= vars.platform_name %> product tiles.
 
-For more information about the Ops Manager API, see the [Ops Manager API documentation](https://docs.pivotal.io/platform/opsman-api). Your Ops Manager serves a local copy of this documentation at `https://YOUR-OPS-MANAGER-FQDN/docs`.
+For more information about the Ops Manager API, see the [Ops Manager API documentation](https://docs.pivotal.io/platform/2-7/opsman-api). Your Ops Manager serves a local copy of this documentation at `https://YOUR-OPS-MANAGER-FQDN/docs`.
 
 ### <a id='related'></a> Related Tools
 


### PR DESCRIPTION
Looks like the version-free redirect is broken, so I fixed this branch to the version-specific one.

I did it on this branch only because this is the Google hit I keep getting when I search for said API docs, so I want the link to work; this may be needed on others, too. It's fine on the 2.10 branch.