### PR TITLE
Remove Datastore.UpdateVirtualMachineFiles from required privileges

### DIFF
--- a/vsphere/vsphere-service-account.html.md.erb
+++ b/vsphere/vsphere-service-account.html.md.erb
@@ -100,9 +100,6 @@ You must grant the following privileges on any entities in a datacenter where yo
     <tr>
         <td>Datastore.FileManagement</td>
     </tr>
-    <tr>
-        <td>Datastore.UpdateVirtualMachineFiles</td>
-    </tr>
 </table>
 
 ### <a id="folder"></a>Folder Object


### PR DESCRIPTION
* removed from bosh vSphere CPI requirements [here](https://github.com/cloudfoundry/bosh-vsphere-cpi-release/commit/eb592bd346327f5a35dd2d3a6c209e297193f6fe)

* We don't find any evidence that this privilege was ever necessary and
it's generating a confusing warning on Azure VMware Solution (AVS)

Co-authored-by: Julian Hjortshoj <hjortshojj@vmware.com>
Co-authored-by: Mark Stokan <mstokan@pivotal.io>

[Tracker Story:](https://www.pivotaltracker.com/story/show/177673407) OpsMan warns about unneeded Datastore.UpdateVirtualMachineFiles privilege