### PR TITLE
Update "Use NSX-T Policy API" Instructions

### DIFF
--- a/vsphere/config.html.md.erb
+++ b/vsphere/config.html.md.erb
@@ -60,7 +60,7 @@ Before you begin this procedure, you must complete all steps in [Deploying <%= v
     * **NSX Networking**: Select this option to enable NSX network virtualization for non-<%= vars.k8s_runtime_abbr %> products such as <%= vars.app_runtime_abbr %>. This virtualization lets you configure component load balancing and security in the product tile [**Resource Config**](#resource-config) pane.
     Configure NSX networking by entering the following information:
         * **NSX Mode**: Select either **NSX-V** or **NSX-T**.
-        * **Use NSX-T Policy API**: Leave disabled. This feature is experimental.
+        * **Use NSX-T Policy API**: Select whether to use the NSX-T Policy API instead of the Manager API when placing VMs in NSX-T groups and server pools. (NSX-T groups or server pools can be used to designate VMs as load balancer backends.) This feature requires NSX-T Data Center v3.0 or later.
         * **NSX Address**: The address of the NSX Manager.
         * **NSX-T Authentication**: Select how BOSH Director authenticates to the NSX Manager:
             * **Local User Authentication** authenticates with a username and password.


### PR DESCRIPTION
- Policy API code is no longer experimental in the vSphere CPI. This commit replaces the "leave disabled." instruction with a description of the feature.