### PR TITLE
Update release-notes.html.md.erb

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -51,7 +51,7 @@ on the Cloud Foundry website.
 
 **Release Date:** September 16, 2021
 
-- **[Known Issue]** TKGi customers are recommended to skip this version. Deployments using the `disk.enableUUID` vmx option and attaching additional SCSI devices (for example, TKGi clusters using persistent volumes) may experience data loss if the VM is powered off and powered on again. This is due to a functional regression causing the VM to mount the wrong disk at startup. This regression is fixed in version 2.10.18.
+- **[Known Issue]** TKGI customers are recommended to skip this version. Deployments using the `disk.enableUUID` vmx option and attaching additional SCSI devices (for example, TKGI clusters using persistent volumes) may experience data loss if the VM is powered off and powered on again. This is due to a functional regression causing the VM to mount the wrong disk at startup. This regression is fixed in version 2.10.18.
 
 - **[Bug Fix]** NSX-T server pools can be configured without a port
 - **[Bug Fix]** An error is now returned by the API when using duplicate GUIDs while updating vSphere clusters.


### PR DESCRIPTION
The official acronym is (now) TKGI (as https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid-Integrated-Edition/index.html)
TKGi -> TKGI