### PR TITLE
wrong version for cert durations

### DIFF
--- a/security/pcf-infrastructure/configure-certificate-duration-overrides.html.md.erb
+++ b/security/pcf-infrastructure/configure-certificate-duration-overrides.html.md.erb
@@ -8,7 +8,7 @@ This topic describes how to set values to override the duration for certificate 
 ## <a id='overview'></a> Overview
 
 By default, certificates that <%= vars.ops_manager %> and CredHub generate use the duration set by the tile and certificate authors. These durations can vary from certificate to certificate.
-In <%= vars.ops_manager %> v2.10.17 and later, you can set values to override the durations for CA and leaf certificates.
+In <%= vars.ops_manager %> v2.10.19 and later, you can set values to override the durations for CA and leaf certificates.
 When you apply an override, you can increase certificate duration and reduce the frequency of required certificate rotations.
 
 The following table describes what happens when you enable this feature:


### PR DESCRIPTION
context in slack: https://vmware.slack.com/archives/C0554UNSS/p1634145449288500