### PR TITLE
Add list of commonly used special cert procedures

### DIFF
--- a/security/pcf-infrastructure/rotate-cas-and-leaf-certs.html.md.erb
+++ b/security/pcf-infrastructure/rotate-cas-and-leaf-certs.html.md.erb
@@ -390,6 +390,16 @@ To delete the old <%= vars.ops_manager %> root CA and mark the old CredHub CAs a
       ```
      Where `SERVICE-INSTANCE-DEPLOYMENT` is the BOSH deployment name for the service instance.
 
+## <a id='specialized-procedures'></a> Certificates with Specialized Procedures
+
+Some certificates are not rotated when using the standard rotation procedure above. The following are certificates that use a separate, specialized rotation procedure.
+
+| Certificate | Tile | Procedure |
+|-------------|------|-----------|
+| `/services/tls_ca` | - | [Rotating the Services TLS CA and Its Leaf Certificates](services_tls_ca_rotate.html) |
+| `/telemetry-ca-cert` | Telemetry v1.2.1 and earlier | [How to rotate the telemetry-ca-cert in Operations Manager](https://community.pivotal.io/s/article/How-to-rotate-the-telemetry-ca-cert) |
+| `/services/tls_leaf` | <%= vars.app_runtime_abbr %> v2.10.0 - v2.10.13 | [Rotate /services/tls_leaf manually](https://community.pivotal.io/s/article/Rotate-services-tls-leaf-manually) |
+
 
 ## <a id='troubleshooting'></a> Troubleshooting
 

--- a/security/pcf-infrastructure/rotate-configurable-certs.html.md.erb
+++ b/security/pcf-infrastructure/rotate-configurable-certs.html.md.erb
@@ -41,6 +41,14 @@ To rotate configurable leaf certificates:
 
 1. Click **Apply Changes**.
 
+## <a id='specialized-procedures'></a> Certificates with Specialized Procedures
+
+Some certificates are not rotated when using the standard rotation procedure above. The following are certificates that use a separate, specialized rotation procedure.
+
+| Certificate | Tile | Procedure |
+|-------------|------|-----------|
+| `.properties.saml_service_provider_cert` | BOSH Director | [How to check and rotate Ops Manager SAML Certificate before it expires](https://community.pivotal.io/s/article/how-to-check-and-rotate-ops-manager-saml-certificate-before-it-expires) |
+| `.uaa.service_provider_key_credentials` | <%= vars.app_runtime_abbr %> | [Rotating Identity Provider SAML Certificates](rotate-saml-ca.html) |
 
 ## <a id='troubleshooting'></a> Troubleshooting
 


### PR DESCRIPTION
This adds a section to our certificate rotation docs that list out
certificates that aren't covered by the standard rotation procedure.
The proper docs page or KB article is linked.

[#181079392] Add KB links for special rotation procedures to the official Ops Manager rotation docs

Signed-off-by: Long Nguyen <nguyenlo@vmware.com>