### PR TITLE
The version is wrong.

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -26,7 +26,7 @@ on the Cloud Foundry website.
 **Release Date:** February 16, 2022
 
 - **[Known Issue]** The API endpoint `/api/v0/staged/director/pre_deploy_check` fails in vSphere environments with an `Internal Server Error`.
-- **[Bug Fix]** An additional BOSH CLI issue introduced in [v2.9.28](#2-9-28) is resolved in this release. This issue caused deployment failures if a Tile used a compiled BOSH release that shared some packages with a BOSH release already uploaded to the BOSH director.
+- **[Bug Fix]** An additional BOSH CLI issue introduced in [v2.10.28](#2-10-28) is resolved in this release. This issue caused deployment failures if a Tile used a compiled BOSH release that shared some packages with a BOSH release already uploaded to the BOSH director.
 - **[Bug Fix]** BOSH deployments failing when enabling Spot Instances via VM Extensions is resolved in this release.
 - **[Feature]** The BOSH Blobstore is now configured to only allow TLS communication. Communication was previously done via TLS, but non-TLS requests were still allowed.
 


### PR DESCRIPTION
One of the fix mentions Ops Manager v2.9.28 but it should be v2.10.28.