### PR TITLE
Update network paths, document log_cache instance group

### DIFF
--- a/security/networking/bosh-dns-network-paths.html.md.erb
+++ b/security/networking/bosh-dns-network-paths.html.md.erb
@@ -26,6 +26,7 @@ The following table lists network communication paths for BOSH DNS. For informat
 | Any VM running BOSH DNS | diego_database | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | doppler | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | ha_proxy | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
+| Any VM running BOSH DNS | log_cache | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | loggregator_trafficcontroller | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | mysql | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | mysql_monitor<sup>&#42;</sup> | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
@@ -46,6 +47,7 @@ The following table lists network communication paths for BOSH DNS. For informat
 | Any VM running BOSH DNS | diego_database | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | doppler | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | ha_proxy | 8853 | TCP | HTTPS | Mutual TLS |
+| Any VM running BOSH DNS | log_cache | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | loggregator_trafficcontroller | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | mysql | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | mysql_monitor<sup>&#42;</sup> | 8853 | TCP | HTTPS | Mutual TLS |

--- a/security/networking/bosh-dns-network-paths.html.md.erb
+++ b/security/networking/bosh-dns-network-paths.html.md.erb
@@ -16,49 +16,45 @@ The following table lists network communication paths for BOSH DNS. For informat
 
 | Source VM | Destination VM | Port | Transport Layer Protocol | App Layer Protocol | Security and Authentication |
 | --------- | -------------- | ---- | ------------------------ | ------------------ | ---------------------------- |
-| Any VM running BOSH DNS | backup-prepare | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
-| Any VM running BOSH DNS | ccdb | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
+| Any VM running BOSH DNS | backup_restore | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | clock_global | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | cloud_controller | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | cloud_controller_worker | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
-| Any VM running BOSH DNS | consul_server | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
+| Any VM running BOSH DNS | credhub | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | diego_brain | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | diego_cell | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
-| Any VM running BOSH DNS | diego_database| 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
+| Any VM running BOSH DNS | diego_database | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | doppler | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | ha_proxy | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | loggregator_trafficcontroller | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
-| Any VM running BOSH DNS | mysql_proxy<sup>&#42;</sup> | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
+| Any VM running BOSH DNS | mysql | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | mysql_monitor<sup>&#42;</sup> | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
+| Any VM running BOSH DNS | mysql_proxy<sup>&#42;</sup> | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | nats | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | nfs_server<sup>&#8224;</sup> | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | router | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | tcp_router | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | uaa | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
-| Any VM running BOSH DNS | uaadb | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
 | Any VM running BOSH DNS | Service tile VMs | 53 | TCP and UDP | DNS | Unencrypted. This communication happens inside the VM. |
-| Any VM running BOSH DNS | backup-prepare | 8853 | TCP | HTTPS | Mutual TLS |
-| Any VM running BOSH DNS | ccdb | 8853 | TCP | HTTPS | Mutual TLS |
+| Any VM running BOSH DNS | backup_restore | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | clock_global | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | cloud_controller | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | cloud_controller_worker | 8853 | TCP | HTTPS | Mutual TLS |
-| Any VM running BOSH DNS | consul_server | 8853 | TCP | HTTPS | Mutual TLS |
+| Any VM running BOSH DNS | credhub | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | diego_brain | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | diego_cell | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | diego_database | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | doppler | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | ha_proxy | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | loggregator_trafficcontroller | 8853 | TCP | HTTPS | Mutual TLS |
-| Any VM running BOSH DNS | mysql_proxy<sup>&#42;</sup> | 8853 | TCP | HTTPS | Mutual TLS |
+| Any VM running BOSH DNS | mysql | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | mysql_monitor<sup>&#42;</sup> | 8853 | TCP | HTTPS | Mutual TLS |
+| Any VM running BOSH DNS | mysql_proxy<sup>&#42;</sup> | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | nats | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | nfs_server<sup>&#8224;</sup> | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | router | 8853 | TCP | HTTPS | Mutual TLS |
-| Any VM running BOSH DNS | syslog_adapter | 8853 | TCP | HTTPS | Mutual TLS |
-| Any VM running BOSH DNS | syslog_scheduler | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | tcp_router | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | uaa | 8853 | TCP | HTTPS | Mutual TLS |
-| Any VM running BOSH DNS | uaadb | 8853 | TCP | HTTPS | Mutual TLS |
 | Any VM running BOSH DNS | Service tile VMs | 8853 | TCP | HTTPS | Mutual TLS |
 
 <sup>&#42;</sup>Applies only to deployments where internal MySQL is selected as the database.

--- a/security/networking/cc-network-paths.html.md.erb
+++ b/security/networking/cc-network-paths.html.md.erb
@@ -20,7 +20,7 @@ The following table lists network communication paths that are inbound to the Cl
 | diego_brain (SSH Proxy) | cloud_controller | 9024 | TCP | HTTPS | OAuth 2.0 |
 | diego_cell (Rep) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | diego_database (BBS) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
-| doppler (Log Cache CF Auth Proxy) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
+| log_cache (Log Cache CF Auth Proxy) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | loggregator_trafficcontroller (Traffic Controller) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | loggregator_trafficcontroller (Reverse Log Proxy) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | router | cloud_controller | 9024 | TCP | HTTPS | OAuth 2.0 |

--- a/security/networking/cc-network-paths.html.md.erb
+++ b/security/networking/cc-network-paths.html.md.erb
@@ -15,12 +15,14 @@ The following table lists network communication paths that are inbound to the Cl
 | Source VM | Destination VM | Port | Transport Layer Protocol | App Layer Protocol | Security and Authentication |
 | --------- | -------------- | ---- | ------------------------ | ------------------ | ---------------------------- |
 | cloud_controller | cloud_controller (Routing API) | 443 | TCP | HTTPS | OAuth 2.0 |
+| clock_global (Syslog Binding Cache) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | diego_brain | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | diego_brain (SSH Proxy) | cloud_controller | 9024 | TCP | HTTPS | OAuth 2.0 |
 | diego_cell (Rep) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | diego_database (BBS) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
-| doppler (Syslog Drain Binder) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
-| loggregator_trafficcontroller | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
+| doppler (Log Cache CF Auth Proxy) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
+| loggregator_trafficcontroller (Traffic Controller) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
+| loggregator_trafficcontroller (Reverse Log Proxy) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | router | cloud_controller | 9024 | TCP | HTTPS | OAuth 2.0 |
 
 

--- a/security/networking/loggregator-network-paths.html.md.erb
+++ b/security/networking/loggregator-network-paths.html.md.erb
@@ -15,15 +15,14 @@ The following table lists network communication paths for Loggregator:
 | Source VM | Destination VM | Port | Transport Layer Protocol | App Layer Protocol | Security and Authentication |
 | --------- | -------------- | ---- | ------------------------ | ------------------ | ---------------------------- |
 | Any&#42; | loggregator_trafficcontroller | 8081 | TCP | HTTP/WebSocket | OAuth |
-| Any VM running Metron | doppler | 8082 | TCP | gRPC over HTTP/2 | Mutual TLS |
+| Any VM running Loggregator Agent | doppler | 8082 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | loggregator_trafficcontroller | doppler | 8082 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | loggregator_trafficcontroller | uaa | 8443 | TCP | HTTPS | TLS |
 | loggregator_trafficcontroller | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | loggregator_trafficcontroller (Reverse Log Proxy) | doppler | 8082 | TCP | gRPC over HTTP/2 | Mutual TLS |
-| Any&#42; | loggregator_trafficcontroller (<%= vars.app_runtime_abbr %> authentication proxy) | 8083 | TCP | HTTP | OAuth |
 | loggregator_trafficcontroller (Route Registrar) | nats | 4222 | TCP | NATS | Basic authentication |
 | loggregator_trafficcontroller (Metrics Forwarder) | BOSH Director (Metrics Server) | 25555 and 8443 | TCP | gRPC over HTTP/2 | Mutual TLS |
-| loggregator_trafficcontroller | doppler (Log Cache) | 8080 | TCP | gRPC over HTTP/2 | Mutual TLS |
+| loggregator_trafficcontroller | log_cache | 8080 | TCP | gRPC over HTTP/2 | Mutual TLS |
 | loggregator_trafficcontroller (Reverse Log Proxy Gateway) | cloud_controller | 9023 | TCP | HTTPS | Mutual TLS |
 | Any&#42; | loggregator_trafficcontroller (Reverse Log Proxy Gateway) | 8088 | TCP | HTTP/Server Sent Events | OAuth |
 
@@ -42,12 +41,15 @@ The following table lists network communication paths for Log Cache:
 
 | Source VM | Destination VM | Port | Transport Layer Protocol | App Layer Protocol | Security and Authentication |
 | --------- | -------------- | ---- | ------------------------ | ------------------ | ---------------------------- |
-| loggregator_trafficcontroller (Reverse Log Proxy) | log-cache (Nozzle) | 8082 | TCP | gRPC over HTTP/2 | Mutual TLS |
-| Any&#42; | log-cache | 8080 | TCP | gRPC over HTTP/2 | Mutual TLS |
-| gorouter | log-cache (Auth Proxy) | 8083 | TCP | HTTP | OAuth |
-| log-cache (Auth Proxy) | uaa | 8443 | TCP | HTTPS | TLS |
-| log-cache (Auth Proxy) | cloud_controller | 9024 | TCP | HTTPS | TLS |
+| Any VM running Loggregator Syslog Agent&#42; | log_cache | 6667 | TCP | Syslog | TLS |
+| Any&#42;&#42; | log_cache | 8080 | TCP | gRPC over HTTP/2 | Mutual TLS |
+| log_cache (Nozzle)&#42;&#42;&#42; | loggregator_trafficcontroller (Reverse Log Proxy) | 8082 | TCP | gRPC over HTTP/2 | Mutual TLS |
+| gorouter | log_cache (Auth Proxy) | 8083 | TCP | HTTP | OAuth |
+| log_cache (Auth Proxy) | uaa | 8443 | TCP | HTTPS | TLS |
+| log_cache (Auth Proxy) | cloud_controller | 9024 | TCP | HTTPS | TLS |
 
-<sup>&#42;</sup>Any source VM can send requests to the specified destination within its subnet.
+<sup>&#42;</sup>When Log Cache is configured to use Syslog ingestion.
+<sup>&#42;&#42;</sup>Any source VM can send requests to the specified destination within its subnet.
+<sup>&#42;&#42;&#42;</sup>When Log Cache is configured to use Reverse Log Proxy ingestion.
 
 <%= partial "bosh-dns" %>


### PR DESCRIPTION
* Update the docs to reflect the upcoming change to split out Log Cache to its own `log_cache` instance group.
* The instance groups in the BOSH DNS documentation seemed quite out of date so I updated those
* As discussed it might make sense to restructure the docs so that TAS version-specific documentation on network paths is not held within the Ops Manager docs.