### PR TITLE
Update advanced-certificate-rotation.html.md.erb

### DIFF
--- a/security/pcf-infrastructure/advanced-certificate-rotation.html.md.erb
+++ b/security/pcf-infrastructure/advanced-certificate-rotation.html.md.erb
@@ -256,13 +256,6 @@ To rotate the Services TLS CA and its leaf certificates:
         maestro regenerate ca --name "/services/tls_ca" --force
         ```
 
-1. Tell <%= vars.ops_manager %> to trust your new Services TLS CA certificate:
-    1. In <%= vars.ops_manager %>, paste the certificate into the **BOSH Director > Security > Trusted Certificates** field.
-    1. Click **Save**.
-    1. In the <%= vars.app_runtime_abbr %> and Isolation Segment tiles, paste the certificate into the **Networking** > <%= vars.ca_trust_gorouter_haproxy_fields %>.
-    1. Click **Save**.
-
-
 1. Re-deploy:
     1. Return to the <%= vars.ops_manager %> Installation Dashboard.
     1. On the **Review Pending Changes** page, enable the **Select All Products** checkbox.


### PR DESCRIPTION
The removed section is a remnant from a prior procedure (Manual credhub version) that is not necessary in the maestro packaged with ops manager 2.10+. The instructions listed here are incompletely copied from the prior procedure and cause confusion. After discussion with ops-manager R&D it was agreed to remove this section.