### PR TITLE
PKS link correction from the field

### DIFF
--- a/vsphere/config.html.md.erb
+++ b/vsphere/config.html.md.erb
@@ -15,7 +15,7 @@ After you complete this procedure, follow the configuration instructions for the
 
 * To install <%= vars.app_runtime_first %>, see the [<%= vars.app_runtime_abbr %> documentation](https://docs.pivotal.io/application-service/operating/configure-pas.html).
 
-* To install <%= vars.k8s_runtime_abbr %>, see the [<%= vars.k8s_runtime_abbr %> documentation](https://docs.pivotal.io/pks/installing-pks-vsphere.html).
+* To install <%= vars.k8s_runtime_abbr %>, see the [<%= vars.k8s_runtime_abbr %> documentation](https://docs.vmware.com/en/VMware-Tanzu-Kubernetes-Grid-Integrated-Edition/1.16/tkgi/GUID-vsphere-flannel.html).
 
 For more information about <%= vars.ops_manager_first %> runtimes, see [Installing Runtimes](../install/runtimes.html).
 


### PR DESCRIPTION
https://docs.pivotal.io/pks/installing-pks-vsphere.html  redirects to a 404 error.

From Slack: https://vmware.slack.com/archives/C8DJ383EX/p1678167951859009?thread_ts=1678109180.785849&cid=C8DJ383EX