### PR TITLE
Document vSphere + NSX-T version requirements

### DIFF
--- a/install/vsphere.html.md.erb
+++ b/install/vsphere.html.md.erb
@@ -27,6 +27,26 @@ This section describes the resource requirements for installing <%= vars.ops_man
 
 <p class='note'><strong>Note:</strong> When installing <%= vars.ops_manager %> on a vSphere environment with multiple ESXi hosts, you must use network-attached or shared storage devices. Local storage devices do not support sharing across multiple ESXi hosts.</p>
 
+### <a id='version'></a> Version Requirements
+
+<%= vars.ops_manager %> can be installed on and the BOSH Director tile within <%= vars.ops_manager %> can be configured with the following versions of vSphere:
+
+* vSphere v8.0
+
+* vSphere v7.0
+
+* vSphere v6.7
+
+* vSphere v6.5
+
+The BOSH Director tile within <%= vars.ops_manager %> can optionally be configured with the following versions of NSX-T:
+
+* NSX-T v4.0
+
+* NSX-T v3.1
+
+* NSX-T v3.0
+
 ### <a id='runtimes'></a> Resource Requirements
 
 You can install <%= vars.ops_manager %> with one of two runtimes. For more information about the requirements for each runtime, see the following:


### PR DESCRIPTION
Previously, this was indirectly documented in the TAS documentation. However, we have split the TAS and Ops Manager docs since that time, so it is more appropriate to document the versions in Ops Manager's documentation.

[#184498775] Update docs to talk about vSphere 8 support