### PR TITLE
Improved messaging around possible nats credential issues

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -36,6 +36,8 @@ Dashboard. For more information, see [Rotate Non-Configurable Leaf Certificates 
 * **[Feature]** You can configure your VMs to use short-lived NATS credentials during the bootstrap process. For more information, see [Short-Lived NATS
 Bootstrap Credentials](#short-lived-nats-creds) below.
 
+<p class='note caution'><strong>Caution:</strong> Before turning on short-lived NATS credentials, you should ensure all VMs (including those deployed by service tiles) are using stemcells that support this feature, otherwise you risk encountering unresponsive VMs. Please reference the [documentation for NATS short-lived credentials](security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html) for more information on supported stemcells.</p>
+
 * **[Feature Improvement]** <%= vars.ops_manager %> <%= vars.v_major_version %> uses Rails 7.0.
 
 * **[Feature Improvement]** <%= vars.ops_manager %> <%= vars.v_major_version %> uses Node 18.

--- a/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
+++ b/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
@@ -54,6 +54,9 @@ short-lived bootstrap credentials, you must re-create them.
     <li>Windows 2019.41 and later</li>
     <li>Xenial 621.171 and later</li>
     <li>Bionic 1.36 and later</li>
-    <li>All versions of Jammy</li>
+    <li>Jammy 1.95 and later</li>
   </ul>
+
+  Please note: All Jammy versions are compatible with the short-lived NATS credentials feature; however, Jammy versions prior to 1.95 contain a known issue when this feature is active that causes failures if a VM is recreated while a disk resize occurs.
+
   If you configure short-lived bootstrap credentials for VMs using unsupported stemcells, the VMs become unresponsive.</div>


### PR DESCRIPTION
This is an amendment that helps highlight some of the issues users might experience when using the new short-lived NATS credentials. Not urgent to get in same day, but good to have when you get a chance. 

Thank you! 