### PR TITLE
Short lived nats credentials 2.10

### DIFF
--- a/common/_director-config.html.md.erb
+++ b/common/_director-config.html.md.erb
@@ -50,9 +50,6 @@ To configure the **Director Config** pane:
 1. Select **Enable Post Deploy Scripts** to run a post-deploy script after deployment. This script allows the job to execute additional commands against a deployment.
     <p class='note'><strong>Note:</strong> If you intend to install <%= vars.k8s_runtime_first %>, you must enable post-deploy scripts.</p>
 
-2. Select **Enable Short Lived NATS Bootstrap Credentials** to rotate the bootstrap NATS credentials. This feature increases security by [rotating the bootstrap credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html) that are used when starting the VMs.
-    <p class='note'><strong>Note:</strong> This feature moderately slows the creation of a VM since it restarts the BOSH Agent.</p>
-
 1. Select **Recreate VMs deployed by the BOSH Director** to force BOSH to re-create BOSH-deployed VMs on the next deploy. This process does not re-create the BOSH Director VM or destroy any persistent disk data. This checkbox is cleared automatically after a successful re-deployment.
 
 1. Select **Recreate BOSH Director VMs** to force the BOSH Director VM to be re-created on the next deploy. This process does not destroy any persistent disk data. This checkbox is cleared automatically after a successful re-deployment.

--- a/common/_director-config.html.md.erb
+++ b/common/_director-config.html.md.erb
@@ -51,7 +51,7 @@ To configure the **Director Config** pane:
     <p class='note'><strong>Note:</strong> If you intend to install <%= vars.k8s_runtime_first %>, you must enable post-deploy scripts.</p>
 
 2. Select **Enable Short Lived NATS Bootstrap Credentials** to rotate the bootstrap NATS credentials. This feature increases security by [rotating the bootstrap credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html) that are used when starting the VMs.
-    <p class='note'><strong>Note:</strong> This feature will make the BOSH Agent restart when creating a VM, and will make the creation of a VM moderately slower.</p>
+    <p class='note'><strong>Note:</strong> This feature moderately slows the creation of a VM since it restarts the BOSH Agent.</p>
 
 1. Select **Recreate VMs deployed by the BOSH Director** to force BOSH to re-create BOSH-deployed VMs on the next deploy. This process does not re-create the BOSH Director VM or destroy any persistent disk data. This checkbox is cleared automatically after a successful re-deployment.
 

--- a/common/_director-config.html.md.erb
+++ b/common/_director-config.html.md.erb
@@ -50,6 +50,9 @@ To configure the **Director Config** pane:
 1. Select **Enable Post Deploy Scripts** to run a post-deploy script after deployment. This script allows the job to execute additional commands against a deployment.
     <p class='note'><strong>Note:</strong> If you intend to install <%= vars.k8s_runtime_first %>, you must enable post-deploy scripts.</p>
 
+2. Select **Enable Short Lived NATS Bootstrap Credentials** to rotate the bootstrap NATS credentials. This feature increases security by [rotating the bootstrap credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html) that are used when starting the VMs.
+    <p class='note'><strong>Note:</strong> This feature will make the BOSH Agent restart when creating a VM, and will make the creation of a VM moderately slower.</p>
+
 1. Select **Recreate VMs deployed by the BOSH Director** to force BOSH to re-create BOSH-deployed VMs on the next deploy. This process does not re-create the BOSH Director VM or destroy any persistent disk data. This checkbox is cleared automatically after a successful re-deployment.
 
 1. Select **Recreate BOSH Director VMs** to force the BOSH Director VM to be re-created on the next deploy. This process does not destroy any persistent disk data. This checkbox is cleared automatically after a successful re-deployment.

--- a/opsguide/index.html.md.erb
+++ b/opsguide/index.html.md.erb
@@ -41,7 +41,7 @@ This guide includes the following topics:
     *   [Rotating Identity Provider SAML Certificates](/docs-ops-manager/security/pcf-infrastructure/rotate-saml-ca.html)
     *   [Custom Certificate Authorities](/docs-ops-manager/security/pcf-infrastructure/custom-ca-cert.html)
     *   [Retrieving Credentials from Your Deployment](/docs-ops-manager/install/credentials.html)
-    *   [NATS Short Lived Bootstrap Credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html)
+    *   [Using Short-Lived NATS Bootstrap Credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html)
     *   [CredHub-Managed Certificates and Credentials](/docs-ops-manager/security/pcf-infrastructure/credhub-index.html)
         *   [CredHub](https://docs.pivotal.io/credhub/index.html)
         *   [CredHub Credential Types](https://docs.pivotal.io/credhub/credential-types.html)

--- a/opsguide/index.html.md.erb
+++ b/opsguide/index.html.md.erb
@@ -41,6 +41,7 @@ This guide includes the following topics:
     *   [Rotating Identity Provider SAML Certificates](/docs-ops-manager/security/pcf-infrastructure/rotate-saml-ca.html)
     *   [Custom Certificate Authorities](/docs-ops-manager/security/pcf-infrastructure/custom-ca-cert.html)
     *   [Retrieving Credentials from Your Deployment](/docs-ops-manager/install/credentials.html)
+    *   [NATS Short Lived Bootstrap Credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html)
     *   [CredHub-Managed Certificates and Credentials](/docs-ops-manager/security/pcf-infrastructure/credhub-index.html)
         *   [CredHub](https://docs.pivotal.io/credhub/index.html)
         *   [CredHub Credential Types](https://docs.pivotal.io/credhub/credential-types.html)

--- a/security/pcf-infrastructure/certs-index.html.md.erb
+++ b/security/pcf-infrastructure/certs-index.html.md.erb
@@ -17,6 +17,7 @@ This guide includes the following topics:
 *   [Rotating Identity Provider SAML Certificates](/docs-ops-manager/security/pcf-infrastructure/rotate-saml-ca.html)
 *   [Custom Certificate Authorities](/docs-ops-manager/security/pcf-infrastructure/custom-ca-cert.html)
 *   [Retrieving Credentials from Your Deployment](/docs-ops-manager/install/credentials.html)
+*   [NATS Short Lived Bootstrap Credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html)
 *   [CredHub-Managed Certificates and Credentials](/docs-ops-manager/security/pcf-infrastructure/credhub-index.html)
     *   [CredHub](/docs-ops-manager/security/pcf-infrastructure/credhub.html)
     *   [CredHub Credential Types](/docs-ops-manager/security/pcf-infrastructure/credhub-credential-types.html)

--- a/security/pcf-infrastructure/certs-index.html.md.erb
+++ b/security/pcf-infrastructure/certs-index.html.md.erb
@@ -17,7 +17,7 @@ This guide includes the following topics:
 *   [Rotating Identity Provider SAML Certificates](/docs-ops-manager/security/pcf-infrastructure/rotate-saml-ca.html)
 *   [Custom Certificate Authorities](/docs-ops-manager/security/pcf-infrastructure/custom-ca-cert.html)
 *   [Retrieving Credentials from Your Deployment](/docs-ops-manager/install/credentials.html)
-*   [NATS Short Lived Bootstrap Credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html)
+*   [Using Short-Lived NATS Bootstrap Credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html)
 *   [CredHub-Managed Certificates and Credentials](/docs-ops-manager/security/pcf-infrastructure/credhub-index.html)
     *   [CredHub](/docs-ops-manager/security/pcf-infrastructure/credhub.html)
     *   [CredHub Credential Types](/docs-ops-manager/security/pcf-infrastructure/credhub-credential-types.html)

--- a/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
+++ b/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
@@ -1,30 +1,59 @@
 ---
-title: NATS Short Lived Bootstrap Credentials
+title: Using Short-Lived NATS Bootstrap Credentials
 owner: Ops Manager
 ---
 
-## <a id='overview'></a> Overview
+This topic describes using short-lived NATS bootstrap credentials in your <%= vars.ops_manager_full %> deployment.
 
-The BOSH NATS is a service that enables communication between the BOSH Director and the BOSH Agent in the deployed VMs. It is used to send messages to the BOSH Agent so it can execute tasks or return information of the current state of the VM. The authentication mechanism for the BOSH NATS is based on TLS certificates. Each VM deployed by BOSH is given a certificate at startup so the Agent can communicate safely with NATS. This certificate is delivered using each IAAS metadata service (e.g. [AWS user-data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html)).
 
-## <a id='problem'></a> Problem
+## <a id='overview'></a> Overview of Short-Lived NATS Bootstrap Credentials
 
-The delivery mechanism used by BOSH to pass the certificate to the VMs is based on the IAAS metadata services. This mechanism is not secure because in the IaaSes the VM metadata is accessible by any process running in the VM or by a user with non root access to the VM. This creates the risk of a malicious user or process getting the certificate and using it to communicate with the BOSH NATS.
+BOSH NATS is a service that allows the BOSH Director and BOSH Agents in deployed VMs to communicate with each other. The BOSH Director uses BOSH NATS to send
+commands and information to the BOSH Agent, so that the BOSH Agent can execute tasks or return information about the current state of the VM.
 
-## <a id='solution'></a> Solution
+BOSH NATS uses TLS certificates to authenticate communication between the BOSH Director and the BOSH Agent. When VMs are created during a new deployment of
+<%= vars.ops_manager %>, BOSH gives each VM a TLS certificate through the metadata service for your IaaS, such as AWS instance user data.
 
-The solution is to use a short lived certificate in each VM for BOSH NATS access. The certificate that is given to the VM when it's created will be valid just for the bootstrap process. Before the bootstrap process is completed, the Agent will receive a new certificate using a different mechanism: a message from the Director to the Agent with the updated configuration. The previous certificate stored in the metadata service will be rejected from that point on by the BOSH NATS. No process or user will be able to access the initial certificate before the bootstrap process is completed.
+However, any user with non-root access to a VM or process running in a VM can access VM metadata within your IaaS. This could allow a malicious user or
+process to obtain the TLS certificate for the VM and use it to communicate with the BOSH Director through BOSH NATS.
 
-## <a id='enable'></a> Enable the Short lived NATS bootstrap credentials
+To increase the security of your <%= vars.ops_manager %> deployment, you can configure your VMs to use short-lived bootstrap credentials when communicating
+through BOSH NATS. When you configure your VMs to use short-lived bootstrap credentials, the TLS certificate that BOSH gives to a VM through the metadata
+service for your IaaS contains credentials that are only to be used during the bootstrap process. Before the bootstrap process finishes, the BOSH Director
+sends the BOSH Agent a new TLS certificate. From that point forward, BOSH NATS rejects the previous TLS certificate that is stored in the metadata service.
+Because no user or process can access VMs during the bootstrap process, and apps are installed after the bootstrap process is complete, using short-lived
+bootstrap credentials ensures that any malicious user or process that obtains the TLS certificate stored in the metadata service cannot use it to access your
+VMs or apps.
 
-To enable the short lived NATS bootstrap credentials feature:
+
+## <a id='configure'></a> Configure Short-Lived NATS Bootstrap Credentials
+
+To configure your VMs to use short-lived bootstrap credentials when communicating through BOSH NATS:
+
+1. In a browser window, navigate to the <%= vars.ops_manager %> Installation Dashboard.
 
 1. Click the **BOSH Director** tile.
+
 1. Select **Director Config**.
-1. Scroll down to the **Enable Short Lived NATS Bootstrap Credentials** checkbox and check it.
+
+1. Activate the **Enable Short Lived NATS Bootstrap Credentials** checkbox.
+
 1. Click **Save**.
-1. Click **Apply Changes** on the BOSH Director.
 
-This will affect all new deployments. Existing deployments will not be affected. If you want to enable the feature for existing VMs, you will need to recreate them.
+1. Return to the <%= vars.ops_manager %> Installation Dashboard.
 
-<p class='note important'><strong>Important:</strong><br>This feature is available for the following Stemcells: <br>Windows 2019 - 2019.41 and newer<br>Ubuntu Xenial - 621.171 and newer<br>Ubuntu Bionic - 1.36 and newer<br>Ubuntu Jammy - All versions are supported.<br><br> Using this feature with unsupported stemcells will result in unresponsive VMs</p>
+1. Click **Review Pending Changes**.
+
+1. Click **Apply Changes**.
+
+This configuration affects all new deployments of <%= vars.ops_manager %>. If you want to configure VMs in existing <%= vars.ops_manager %> deployments to use
+short-lived bootstrap credentials, you must re-create them.
+
+<div class='note important'><strong>Important:</strong> You can configure short-lived bootstrap credentials for VMs using the following stemcells:
+  <ul>
+    <li>Windows 2019.41 and later</li>
+    <li>Xenial 621.171 and later</li>
+    <li>Bionic 1.36 and later</li>
+    <li>All versions of Jammy</li>
+  </ul>
+  If you configure short-lived bootstrap credentials for VMs using unsupported stemcells, the VMs become unresponsive.</div>

--- a/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
+++ b/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
@@ -1,0 +1,30 @@
+---
+title: NATS Short Lived Bootstrap Credentials
+owner: Ops Manager
+---
+
+## <a id='overview'></a> Overview
+
+The BOSH NATS is a service that enables communication between the BOSH Director and the BOSH Agent in the deployed VMs. It is used to send messages to the BOSH Agent so it can execute tasks or return information of the current state of the VM. The authentication mechanism for the BOSH NATS is based on TLS certificates. Each VM deployed by BOSH is given a certificate at startup so the Agent can communicate safely with NATS. This certificate is delivered using each IAAS metadata service (e.g. [AWS user-data](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html)).
+
+## <a id='problem'></a> Problem
+
+The delivery mechanism used by BOSH to pass the certificate to the VMs is based on the IAAS metadata services. This mechanism is not secure because in the IaaSes the VM metadata is accessible by any process running in the VM or by a user with non root access to the VM. This creates the risk of a malicious user or process getting the certificate and using it to communicate with the BOSH NATS.
+
+## <a id='solution'></a> Solution
+
+The solution is to use a short lived certificate in each VM for BOSH NATS access. The certificate that is given to the VM when it's created will be valid just for the bootstrap process. Before the bootstrap process is completed, the Agent will receive a new certificate using a different mechanism: a message from the Director to the Agent with the updated configuration. The previous certificate stored in the metadata service will be rejected from that point on by the BOSH NATS. No process or user will be able to access the initial certificate before the bootstrap process is completed.
+
+## <a id='enable'></a> Enable the Short lived NATS bootstrap credentials
+
+To enable the short lived NATS bootstrap credentials feature:
+
+1. Click the **BOSH Director** tile.
+1. Select **Director Config**.
+1. Scroll down to the **Enable Short Lived NATS Bootstrap Credentials** checkbox and check it.
+1. Click **Save**.
+1. Click **Apply Changes** on the BOSH Director.
+
+This will affect all new deployments. Existing deployments will not be affected. If you want to enable the feature for existing VMs, you will need to recreate them.
+
+<p class='note important'><strong>Important:</strong><br>This feature is available for the following Stemcells: <br>Windows 2019 - 2019.41 and newer<br>Ubuntu Xenial - 621.171 and newer<br>Ubuntu Bionic - 1.36 and newer<br>Ubuntu Jammy - All versions are supported.<br><br> Using this feature with unsupported stemcells will result in unresponsive VMs</p>

--- a/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
+++ b/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
@@ -54,6 +54,9 @@ short-lived bootstrap credentials, you must re-create them.
     <li>Windows 2019.41 and later</li>
     <li>Xenial 621.171 and later</li>
     <li>Bionic 1.36 and later</li>
-    <li>All versions of Jammy</li>
+    <li>Jammy 1.95 and later</li>
   </ul>
+
+  Please note: All Jammy versions are compatible with the short-lived NATS credentials feature; however, Jammy versions prior to 1.95 contain a known issue when this feature is active that causes failures if a VM is recreated while a disk resize occurs.
+
   If you configure short-lived bootstrap credentials for VMs using unsupported stemcells, the VMs become unresponsive.</div>

--- a/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
+++ b/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html.md.erb
@@ -30,15 +30,35 @@ VMs or apps.
 
 To configure your VMs to use short-lived bootstrap credentials when communicating through BOSH NATS:
 
-1. In a browser window, navigate to the <%= vars.ops_manager %> Installation Dashboard.
+1. Set <%= vars.ops_manager %> to Advanced Mode by following the procedure in
+[How to Enable Advanced Mode in the <%= vars.ops_manager %>](https://community.pivotal.io/s/article/How-to-Enable-Advanced-Mode-in-the-Ops-Manager?language=en_US)
+in the Knowledge Base.
+For more information about Advanced Mode,
+see [Advanced Mode](https://docs.pivotal.io/ops-manager/2-10/api/#tag/Advanced-Mode)
+in the <%= vars.ops_manager %> API documentation.
 
-1. Click the **BOSH Director** tile.
+  <div class="note caution"><strong>Caution:</strong>
+    <ul>
+      <li><%= vars.company_name %> recommends that only skilled operators use Advanced Mode in <%= vars.ops_manager %>.
+        If you use Advanced Mode incorrectly, you can deactivate or destroy your deployment.</li>
+      <li><%= vars.ops_manager %> does not validate the properties that you change using Advanced Mode.
+        For example, if you enter a string where an integer is required, you do not receive an error.</li>
+    </ul>
+  </div>
 
-1. Select **Director Config**.
+1. Use the `/api/v0/staged/director/overrides` endpoint to override the flag `enable_short_lived_nats_bootstrap_credentials`
+value to `true`.
+The following uaac curl command is an example on how to override the flag to `true`:
+```bash
+uaac curl "http://YOUR-OPS-MAN-FQDN/api/v0/staged/director/overrides" -X PUT --data '{"overrides" : [{"section": "instance_groups", "data": {"director": {"enable_short_lived_nats_bootstrap_credentials": true }}}]}'
+```
+For more information, see
+[Provide a new list of overrides for the BOSH Director](https://docs.pivotal.io/ops-manager/2-10/api/#tag/Advanced-Manifest-Configuration/paths/~1api~1v0~1staged~1director~1overrides/put)
+in the <%= vars.ops_manager %> API documentation.
 
-1. Activate the **Enable Short Lived NATS Bootstrap Credentials** checkbox.
-
-1. Click **Save**.
+1. After you have completed your changes, deactivate Advanced Mode by following the procedure in
+[How to Enable Advanced Mode in the Ops Manager](https://community.pivotal.io/s/article/How-to-Enable-Advanced-Mode-in-the-Ops-Manager?language=en_US)
+in the Knowledge Base.
 
 1. Return to the <%= vars.ops_manager %> Installation Dashboard.
 
@@ -48,6 +68,9 @@ To configure your VMs to use short-lived bootstrap credentials when communicatin
 
 This configuration affects all new deployments of <%= vars.ops_manager %>. If you want to configure VMs in existing <%= vars.ops_manager %> deployments to use
 short-lived bootstrap credentials, you must re-create them.
+
+<div class='note important'><strong>Important:</strong> You can use short-lived NATS bootstrap credentials for <%= vars.ops_manager %> v2.10.54 and above.
+</div>
 
 <div class='note important'><strong>Important:</strong> You can configure short-lived bootstrap credentials for VMs using the following stemcells:
   <ul>

--- a/toc.md.erb
+++ b/toc.md.erb
@@ -102,6 +102,7 @@
         *   [Rotating Identity Provider SAML Certificates](/docs-ops-manager/security/pcf-infrastructure/rotate-saml-ca.html)
         *   [Custom Certificate Authorities](/docs-ops-manager/security/pcf-infrastructure/custom-ca-cert.html)
         *   [Retrieving Credentials from Your Deployment](/docs-ops-manager/install/credentials.html)
+        *   [NATS Short Lived Bootstrap Credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html)
         *   [CredHub-Managed Certificates and Credentials](/docs-ops-manager/security/pcf-infrastructure/credhub-index.html)
             *   [CredHub Documentation](/docs-ops-manager/security/pcf-infrastructure/credhub.html)
             *   [CredHub Credential Types](/docs-ops-manager/security/pcf-infrastructure/credhub-credential-types.html)

--- a/toc.md.erb
+++ b/toc.md.erb
@@ -102,7 +102,7 @@
         *   [Rotating Identity Provider SAML Certificates](/docs-ops-manager/security/pcf-infrastructure/rotate-saml-ca.html)
         *   [Custom Certificate Authorities](/docs-ops-manager/security/pcf-infrastructure/custom-ca-cert.html)
         *   [Retrieving Credentials from Your Deployment](/docs-ops-manager/install/credentials.html)
-        *   [NATS Short Lived Bootstrap Credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html)
+        *   [Using Short-Lived NATS Bootstrap Credentials](/docs-ops-manager/security/pcf-infrastructure/rotate-bootstrap-nats-certificates.html)
         *   [CredHub-Managed Certificates and Credentials](/docs-ops-manager/security/pcf-infrastructure/credhub-index.html)
             *   [CredHub Documentation](/docs-ops-manager/security/pcf-infrastructure/credhub.html)
             *   [CredHub Credential Types](/docs-ops-manager/security/pcf-infrastructure/credhub-credential-types.html)


### PR DESCRIPTION
Ops manager 2.10 does not have a UI to enable the NATS short lived      
credentials, however, the feature can be enabled using an override      
configuration. This PR adds the information of the short lived NATS 
creds to the 2.10 docs and also modifies how to enable them in this     
version.  

This brings all the original commits for the short lived NATS creds 
docs from the 3.0 branch and adds a final correction for 2.10 specific 
things over them. 
