### PR TITLE
Updates supported version list for OpenStack

### DIFF
--- a/install/openstack.html.md.erb
+++ b/install/openstack.html.md.erb
@@ -36,7 +36,7 @@ For <%= vars.app_runtime_abbr %>-specific resource requirements, see [<%= vars.a
 
 The following are OpenStack requirements for deploying <%= vars.ops_manager %>:
 
-* <%= vars.ops_manager %> is supported on the OpenStack Ocata, Pike, Queens, Rocky, and Stein releases. OpenStack is a collection of inter-operable components and requires general OpenStack expertise to troubleshoot issues that may occur when installing <%= vars.ops_manager %> on particular releases and distributions. To verify that your OpenStack platform is compatible with <%= vars.ops_manager %>, use the OpenStack Validator tool. To access the OpenStack Validator tool, see [CF OpenStack Validator](https://github.com/cloudfoundry-incubator/cf-openstack-validator) on GitHub.
+* <%= vars.ops_manager %> is supported on all supported releases of OpenStack. OpenStack is a collection of inter-operable components and requires general OpenStack expertise to troubleshoot issues that may occur when installing <%= vars.ops_manager %> on particular releases and distributions. To verify that your OpenStack platform is compatible with <%= vars.ops_manager %>, use the OpenStack Validator tool. To access the OpenStack Validator tool, see [CF OpenStack Validator](https://github.com/cloudfoundry-incubator/cf-openstack-validator) on GitHub.
 
 * <%= vars.company_name %> recommends granting complete access to the OpenStack logs to the operator managing the <%= vars.ops_manager %> installation process.
 


### PR DESCRIPTION
We've had customers complain about the outdated list of supported OpenStack versions in the documentation.

This commit replaces that explicit list with a more general "It's supported on any supported version" statement that shouldn't need ongoing maintenance.