### PR TITLE
Updates cert rotation docs to mention Jammy

### DIFF
--- a/security/pcf-infrastructure/_skip_recreate_step.html.md.erb
+++ b/security/pcf-infrastructure/_skip_recreate_step.html.md.erb
@@ -1,2 +1,2 @@
-<p> If all VMs are deployed with stemcell Xenial 621.171 or later and Windows 2019.41 or later, you do not
+<p> If all VMs are deployed with stemcell Xenial 621.171 or later or Jammy 1.8 or later and Windows 2019.41 or later, you do not
     need to recreate VMs.</p>


### PR DESCRIPTION
This commit updates the list of stemcell versions that do not require one to recreate VMs during certification rotation.

At least one customer was uncertain if "Xenial 621.171 or later" includes Jammy stemcells, so we update the language to explicitly mention Jammy stemcells.

This is the change for the 3.0 branch of the docs. There is an identical version for 2.10.

If the new language is confusing or bad, then I apologize in advance. Please feel free to change it.