### PR TITLE
Remove references to Azure Stack + Germany

### DIFF
--- a/azure/config-manual.html.md.erb
+++ b/azure/config-manual.html.md.erb
@@ -156,13 +156,6 @@ which is to use a storage tier based on the instance size. For more information,
   To deploy <%= vars.ops_manager %> on Azure using Active Directory Federation Services (ADFS)
   see <a href="https://docs.vmware.com/en/VMware-Tanzu-Operations-Manager/3.0/vmware-tanzu-ops-manager/release-notes.html">IaaS-Specific Global CPI Properties Are Configurable From the API</a>.
 
-13. (Optional) If you clicked `Azure Stack` for your **Azure Environment**, complete the following Azure Stack-only fields:
-  14. For **Domain**, enter the domain for your Azure Stack deployment. For example, `local.azurestack.external`.
-  15. Enter the **Tenant Management Resource Endpoint** from your AzureRM Environment Context. This URL changes with every ASDK installation.
-  16. Enter `AzureAD` for **Authentication**. If you want to use Azure China Cloud Active Directory for your authentication type, enter `AzureChinaCloudAD`.
-  17. Enter your **Azure Stack Endpoint Prefix**. For example `management`.
-  18. Enter your **Azure Stack CA Certificate**. Azure Stack requires a custom CA certificate. Copy the certificate from your Azure Stack environment.
-
 14. Click **Save**.
 
 

--- a/azure/deploy-manual.html.md.erb
+++ b/azure/deploy-manual.html.md.erb
@@ -6,12 +6,10 @@ owner: Ops Manager
 <html class="list-style-none"></html>
 
 You can use these instructions to deploy BOSH and <%= vars.ops_manager_first %> on Azure by using
-individual commands to create resources. <%= vars.company_name %> recommends this manual procedure for deploying to Azure China, Azure Germany, and Azure Government Cloud.
+individual commands to create resources. <%= vars.company_name %> recommends this manual procedure for deploying to Azure China, and Azure Government Cloud.
 
 Before you follow the procedures in this topic, you must do the procedures in [Preparing to Deploy <%= vars.ops_manager %> on Azure](prepare-env-manual.html). After you followed
     the procedures in this topic, follow the instructions in [Configuring BOSH Director on Azure](config-manual.html).
-
-<p> If you deploy BOSH and <%= vars.ops_manager %> on Azure Stack, follow the procedures in <a href="https://docs.microsoft.com/en-us/azure/azure-stack/user/azure-stack-connect-cli">Install and configure CLI for use with Azure Stack</a> in the Microsoft documentation before following the procedures in this topic.</p>
 
 <p> Sometimes Azure portal displays the names of resources with incorrect capitalization. Always use
 the Azure CLI to retrieve the correctly capitalized name of a resource.</p>
@@ -460,8 +458,6 @@ To boot <%= vars.ops_manager %>:
 
     * If you use unmanaged disks, perform the following steps:
 
-        <p> Azure Stack requires unmanaged disks.</p>
-
         1. Download the <%= vars.ops_manager %> image to your local machine. The image size is 10&nbsp;GB.
 
             ```console
@@ -593,11 +589,10 @@ To boot <%= vars.ops_manager %>:
             --os-type Linux
             ```
 
-            If you are using Azure China, Azure Government Cloud, or Azure Germany, replace `blob.core.windows.net` with the following:
+            If you are using Azure China, or Azure Government Cloud, replace `blob.core.windows.net` with the following:
 
             * For Azure China, use `blob.core.chinacloudapi.cn`. For more information, see the [Azure documentation](https://docs.microsoft.com/en-us/azure/china/china-get-started-developer-guide) for more information.
             * For Azure Government Cloud, use `blob.core.usgovcloudapi.net`. For more information, see the [Azure documentation](https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-services-storage) for more information.
-            * For Azure Germany, use `blob.core.cloudapi.de`. For more information, see the [Azure documentation](https://docs.microsoft.com/en-us/azure/germany/germany-developer-guide) for more information.
 
         1. Create your <%= vars.ops_manager %> VM, replacing `PATH-TO-PUBLIC-KEY` with the path to your public key `.pub` file.
 
@@ -615,8 +610,6 @@ To boot <%= vars.ops_manager %>:
             ```
 
 1. If you plan to install more than one tile in this <%= vars.ops_manager %> installation, do the following to increase the size of the <%= vars.ops_manager %> VM disk. You can repeat this process and increase the disk again at a later time if necessary.
-
-    <p> If you use Azure Stack, you must increase the <%= vars.ops_manager %> VM disk size using the Azure Stack UI.</p>
 
     1. Run the following command to stop the VM and detach the disk:
 

--- a/azure/deploy-manual.html.md.erb
+++ b/azure/deploy-manual.html.md.erb
@@ -6,7 +6,7 @@ owner: Ops Manager
 <html class="list-style-none"></html>
 
 You can use these instructions to deploy BOSH and <%= vars.ops_manager_first %> on Azure by using
-individual commands to create resources. <%= vars.company_name %> recommends this manual procedure for deploying to Azure China, and Azure Government Cloud.
+individual commands to create resources. <%= vars.company_name %> recommends this manual procedure for deploying to Azure China and Azure Government Cloud.
 
 Before you follow the procedures in this topic, you must do the procedures in [Preparing to Deploy <%= vars.ops_manager %> on Azure](prepare-env-manual.html). After you followed
     the procedures in this topic, follow the instructions in [Configuring BOSH Director on Azure](config-manual.html).
@@ -589,7 +589,7 @@ To boot <%= vars.ops_manager %>:
             --os-type Linux
             ```
 
-            If you are using Azure China, or Azure Government Cloud, replace `blob.core.windows.net` with the following:
+            If you are using Azure China or Azure Government Cloud, replace `blob.core.windows.net` with the following:
 
             * For Azure China, use `blob.core.chinacloudapi.cn`. For more information, see the [Azure documentation](https://docs.microsoft.com/en-us/azure/china/china-get-started-developer-guide) for more information.
             * For Azure Government Cloud, use `blob.core.usgovcloudapi.net`. For more information, see the [Azure documentation](https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-services-storage) for more information.

--- a/azure/prepare-azure-terraform.html.md.erb
+++ b/azure/prepare-azure-terraform.html.md.erb
@@ -25,7 +25,6 @@ deploy <%= vars.ops_manager %> in order to deploy <%= vars.app_runtime_first %> 
     - **Azure China**: `AzureChinaCloud`. If logging in to <code>AzureChinaCloud</code> fails with
       a `CERT_UNTRUSTED`, use the latest version of node, 4.x or later. For more information about this error, see [Failed to login AzureChinaCloud](https://github.com/Azure/azure-xplat-cli/issues/2725) in the Azure/azure-xplat-cli GitHub repository.
     - **Azure Government Cloud**: `AzureUSGovernment`.
-    - **Azure Germany**: `AzureGermanCloud`.
 
     For example:
     <pre class="terminal">

--- a/azure/prepare-env-manual.html.md.erb
+++ b/azure/prepare-env-manual.html.md.erb
@@ -30,7 +30,6 @@ Microsoft Azure documentation.
       [Failed to login AzureChinaCloud](https://github.com/Azure/azure-xplat-cli/issues/2725) in
       the Azure/azure-xplat-cli GitHub repository.
     - **Azure Government Cloud**: `AzureUSGovernment`.
-    - **Azure Germany**: `AzureGermanCloud`.
 
     For example:
 

--- a/install/azure-arm-template.html.md.erb
+++ b/install/azure-arm-template.html.md.erb
@@ -8,11 +8,7 @@ This topic describes how you can deploy BOSH Director for <%= vars.ops_manager_f
 You can also deploy BOSH Director manually by following the procedure in [Deploying <%= vars.ops_manager %> on Azure](../azure/deploy-manual.html). You must manually deploy if you are deploying to any of the following:
 
 * Azure China
-* Azure Germany
 * Azure Government Cloud
-* Azure Stack (Beta)
-
-<p> Azure Stack is in beta for this release. <%= vars.company_name %> does not recommend using Azure Stack for a production deployment.</p>
 
 Before you perform the procedures in this topic, you must complete the procedures in [Preparing to deploy <%= vars.ops_manager %> on Azure](../azure/prepare-env-manual.html). After you complete the procedures in this topic, follow the instructions in [Configuring BOSH Director on Azure](../azure/config-manual.html).
 
@@ -196,10 +192,9 @@ To copy your <%= vars.ops_manager %> image:
 3. Open the parameters file and enter values for the following parameters:
     * **OpsManVHDStorageAccount:** The name of the storage account you created in [Step 1: Create Storage Account](#storage).
     * **BlobStorageContainer:** The name of the container to which you copied the <%= vars.ops_manager %> VHD.
-    * **BlobStorageEndpoint:** The base URL of the storage endpoint. Leave the default endpoint unless you are using Azure China, Azure Government Cloud, or Azure Germany:
+    * **BlobStorageEndpoint:** The base URL of the storage endpoint. Leave the default endpoint unless you are using Azure China, or Azure Government Cloud:
         * For Azure China, use `blob.core.chinacloudapi.cn`. For more information, see [Azure China developer guide](https://docs.microsoft.com/en-us/azure/china/china-get-started-developer-guide) in the Microsoft Azure documentation.
         * For Azure Government Cloud, use `blob.core.usgovcloudapi.net`. For more information, see [Azure Government storage](https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-services-storage) in the Microsoft Azure documentation.
-        * For Azure Germany, use `blob.core.cloudapi.de`. For more information, see [Azure Germany developer guide](https://docs.microsoft.com/en-us/azure/germany/germany-developer-guide) in the Microsoft Azure documentation.
     * **AdminSSHKey:** The contents of the `opsman.pub` public key file that you created previously.
     * **Location:** The location to install the <%= vars.ops_manager %> VM. For example, `westus`.
     * **Environment:** Tag template-created resources for assisting with resource management.

--- a/install/azure-arm-template.html.md.erb
+++ b/install/azure-arm-template.html.md.erb
@@ -192,7 +192,7 @@ To copy your <%= vars.ops_manager %> image:
 3. Open the parameters file and enter values for the following parameters:
     * **OpsManVHDStorageAccount:** The name of the storage account you created in [Step 1: Create Storage Account](#storage).
     * **BlobStorageContainer:** The name of the container to which you copied the <%= vars.ops_manager %> VHD.
-    * **BlobStorageEndpoint:** The base URL of the storage endpoint. Leave the default endpoint unless you are using Azure China, or Azure Government Cloud:
+    * **BlobStorageEndpoint:** The base URL of the storage endpoint. Leave the default endpoint unless you are using Azure China or Azure Government Cloud:
         * For Azure China, use `blob.core.chinacloudapi.cn`. For more information, see [Azure China developer guide](https://docs.microsoft.com/en-us/azure/china/china-get-started-developer-guide) in the Microsoft Azure documentation.
         * For Azure Government Cloud, use `blob.core.usgovcloudapi.net`. For more information, see [Azure Government storage](https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-services-storage) in the Microsoft Azure documentation.
     * **AdminSSHKey:** The contents of the `opsman.pub` public key file that you created previously.

--- a/install/azure-om-upgrade.html.md.erb
+++ b/install/azure-om-upgrade.html.md.erb
@@ -45,7 +45,6 @@ To export environment variables:
 
     * For Azure China, replace `AzureCloud` with `AzureChinaCloud`. If logging in to `AzureChinaCloud` fails with a `CERT_UNTRUSTED` error, use Node v4 or later.
     * For Azure Government Cloud, replace `AzureCloud` with `AzureUSGovernment`.
-    * For Azure Germany, replace `AzureCloud` with `AzureGermanCloud`.
 
 1. Log in:
 
@@ -300,11 +299,10 @@ To create an <%= vars.ops_manager %> VM instance:
 
             Where `OPS-MANAGER-VERSION` is the version of <%= vars.ops_manager %> you are deploying.
             <br>
-            If you are using Azure China, Azure Government Cloud, or Azure Germany, replace `blob.core.windows.net` with the following:
+            If you are using Azure China, or Azure Government Cloud, replace `blob.core.windows.net` with the following:
 
             * For Azure China, use `blob.core.chinacloudapi.cn`. For more information, see [Azure China developer guide](https://docs.microsoft.com/en-us/azure/china/china-get-started-developer-guide) in the Microsoft Azure documentation.
             * For Azure Government Cloud, use `blob.core.usgovcloudapi.net`. For more information, see [Azure Government storage](https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-services-storage) in the Microsoft Azure documentation.
-            * For Azure Germany, use `blob.core.cloudapi.de`. For more information, see [Azure Germany developer guide](https://docs.microsoft.com/en-us/azure/germany/germany-developer-guide) in the Microsoft Azure documentation.
 
         1. Create your <%= vars.ops_manager %> VM by running: replacing `PATH-TO-PUBLIC-KEY` with the path to your public key `.pub` file, and replacing `opsman-version` and `opsman-image-version` with the version of <%= vars.ops_manager %> you are deploying, for example `opsman-2.0.1`, `opsman-2.0.1-osdisk`, and `opsman-image-2.0.1`.
 
@@ -329,8 +327,6 @@ To create an <%= vars.ops_manager %> VM instance:
 1. If you deploy more than one tile in this <%= vars.ops_manager %> installation, increase the
 size of the <%= vars.ops_manager %> VM disk. You can repeat this process and increase the disk again at
 a later time if necessary.
-
-    <p> If you use Azure Stack, you must increase the <%= vars.ops_manager %> VM disk size using the Azure Stack UI.</p>
 
     1. Stop the VM and detach the disk by running:
 

--- a/install/azure-om-upgrade.html.md.erb
+++ b/install/azure-om-upgrade.html.md.erb
@@ -299,7 +299,7 @@ To create an <%= vars.ops_manager %> VM instance:
 
             Where `OPS-MANAGER-VERSION` is the version of <%= vars.ops_manager %> you are deploying.
             <br>
-            If you are using Azure China, or Azure Government Cloud, replace `blob.core.windows.net` with the following:
+            If you are using Azure China or Azure Government Cloud, replace `blob.core.windows.net` with the following:
 
             * For Azure China, use `blob.core.chinacloudapi.cn`. For more information, see [Azure China developer guide](https://docs.microsoft.com/en-us/azure/china/china-get-started-developer-guide) in the Microsoft Azure documentation.
             * For Azure Government Cloud, use `blob.core.usgovcloudapi.net`. For more information, see [Azure Government storage](https://docs.microsoft.com/en-us/azure/azure-government/documentation-government-services-storage) in the Microsoft Azure documentation.


### PR DESCRIPTION
Support for Azure Stack and Azure Germany was removed in Ops Manager 3.0, so any references to these platforms and configuration fields that were previously removed should be deleted.