### PR TITLE
Fix unclosed code tag on HSM page (3.0)

### DIFF
--- a/install/hsm-config.html.md.erb
+++ b/install/hsm-config.html.md.erb
@@ -147,8 +147,8 @@ To establish a network trust link between a client and your HSMs:
 Where:
 
   <ul>
-      <li>`NUMBER-OF-DAYS` is the number of days you want the network trust link to be valid.</li>
-      <li><code>`CLIENT-HOSTNAME-OR-IP` is the hostname or IP address of the client.</li>
+      <li><code>NUMBER-OF-DAYS</code> is the number of days you want the network trust link to be valid.</li>
+      <li><code>CLIENT-HOSTNAME-OR-IP</code> is the hostname or IP address of the client.</li>
     </ul>
 
 1. Copy the client certificate to your HSM by running:


### PR DESCRIPTION
The unclosed tag is causing rendering errors on the page (i.e. everything after that point is fixed width and green):
<img width="1039" alt="Screenshot 2024-03-12 at 9 11 48 AM" src="https://github.com/pivotal-cf/docs-ops-manager/assets/145077/a5f27dbe-3e6c-4806-93a5-cd6abeb204ee">
