### PR TITLE
Update release notes for 3.0.26

### DIFF
--- a/release-notes.html.md.erb
+++ b/release-notes.html.md.erb
@@ -31,9 +31,8 @@ This release includes a new version of System Metrics, which will cause all VMs 
 </p>
 
 
-- **[Feature]** Tile JavaScript migrations are provided the version of the Tile being upgraded to
-- **[Bug Fix]** Tiles such as NSX-T Container Plugin can assign AZs and networks to the tile for the first time without entering Advanced Mode
-- **[Feature]** Move Ops Manager API docs to a **broadcom.com** URL
+- **[Bug Fix]** AZs and networks can be assigned to previously installed tiles without entering Advanced Mode if the tile is adding Jobs for the first time
+- **[Feature]** Tile JavaScript migrations can now use getUpgradeProductVersion to retrieve the version of the tile being upgraded to
 
 <table border="1" class="nice">
   <thead>
@@ -47,35 +46,6 @@ This release includes a new version of System Metrics, which will cause all VMs 
     <td>Tanzu Ops Manager</td><td>3.0.26-build.1298*</td>
   </tr>
   <tr><td>Stemcell (Bosh Director and Ops Manager)</td><td>1.423*</td></tr><tr><td>BBR SDK</td><td>1.19.11*</td></tr><tr><td>BOSH Director</td><td>280.0.22*</td></tr><tr><td>BOSH DNS</td><td>1.36.12</td></tr><tr><td>System Metrics</td><td>3.0.7*</td></tr><tr><td>CredHub</td><td>2.12.69*</td></tr><tr><td>CredHub Maestro</td><td>9.0.18*</td></tr><tr><td>Syslog</td><td>12.2.4*</td></tr><tr><td>Windows Syslog</td><td>1.2.5*</td></tr><tr><td>UAA</td><td>77.5.0*</td></tr><tr><td>BPM</td><td>1.2.18*</td></tr><tr><td>OS Conf</td><td>22.2.1</td></tr><tr><td>AWS CPI</td><td>102*</td></tr><tr><td>Azure CPI</td><td>49.0.0*</td></tr><tr><td>Google CPI</td><td>49.0.16*</td></tr><tr><td>OpenStack CPI</td><td>54</td></tr><tr><td>vSphere CPI</td><td>97.0.10*</td></tr><tr><td>BOSH CLI</td><td>7.5.6*</td></tr><tr><td>Credhub CLI</td><td>2.9.28*</td></tr><tr><td>BBR CLI</td><td>1.9.63*</td></tr><tr><td>Telemetry</td><td>2.1.5</td></tr><tr><td>Core Consumption</td><td>0.3.15*</td></tr>
-    <td colspan="2"><em>* Components marked with an asterisk have been updated.</em></td>
-  </tbody>
-</table>
-
-### <a id="3-0-26"></a> v3.0.26+LTS-T
-
-**Release Date:** April 16, 2024
-
-<p class="note caution">
-<span class="note__title">Caution</span>
-This release includes a new version of System Metrics, which will cause all VMs to redeploy.
-</p>
-
-
-- **[Feature]** Tile JavaScript migrations are provided the version of the Tile being upgraded to
-- **[Bug Fix]** Tiles such as NSX-T Container Plugin can assign AZs and networks to the tile for the first time without entering Advanced Mode
-
-<table border="1" class="nice">
-  <thead>
-  <tr>
-    <th>Component</th>
-    <th>Version</th>
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    <td>Tanzu Ops Manager</td><td>3.0.26-build.1297*</td>
-  </tr>
-  <tr><td>Stemcell (Bosh Director and Ops Manager)</td><td>1.423*</td></tr><tr><td>BBR SDK</td><td>1.19.11*</td></tr><tr><td>BOSH Director</td><td>280.0.22*</td></tr><tr><td>BOSH DNS</td><td>1.36.12</td></tr><tr><td>System Metrics</td><td>3.0.7*</td></tr><tr><td>CredHub</td><td>2.12.69*</td></tr><tr><td>CredHub Maestro</td><td>9.0.18*</td></tr><tr><td>Syslog</td><td>12.2.4*</td></tr><tr><td>Windows Syslog</td><td>1.2.5*</td></tr><tr><td>UAA</td><td>77.5.0*</td></tr><tr><td>BPM</td><td>1.2.18*</td></tr><tr><td>OS Conf</td><td>22.2.1</td></tr><tr><td>AWS CPI</td><td>102*</td></tr><tr><td>Azure CPI</td><td>48.0.1</td></tr><tr><td>Google CPI</td><td>49.0.16*</td></tr><tr><td>OpenStack CPI</td><td>54</td></tr><tr><td>vSphere CPI</td><td>97.0.10*</td></tr><tr><td>BOSH CLI</td><td>7.5.6*</td></tr><tr><td>Credhub CLI</td><td>2.9.28*</td></tr><tr><td>BBR CLI</td><td>1.9.63*</td></tr><tr><td>Telemetry</td><td>2.1.5</td></tr><tr><td>Core Consumption</td><td>0.3.15*</td></tr>
     <td colspan="2"><em>* Components marked with an asterisk have been updated.</em></td>
   </tbody>
 </table>


### PR DESCRIPTION
Remove the 3.0.26 notes that were added during a failed publish yesterday also.