### PR TITLE
Inline syslog partial for Ops Manager syslog

### DIFF
--- a/pcf-interface.html.md.erb
+++ b/pcf-interface.html.md.erb
@@ -279,7 +279,28 @@ Viewable by administrators only. Configure a custom syslog server for <%= vars.o
 
 To configure a custom syslog endpoint for <%= vars.ops_manager %> logs:
 
-<%= partial "/pcf/ops-manager/syslog_bosh", :locals => { :syslog_context => 'Ops Manager' } %>
+1. Select **Syslog**.
+
+1. (Optional) Select **Yes** to send <%= vars.ops_manager %> system logs to a remote server.
+
+1. Enter the IP address or DNS name for the remote server in **Address**.
+
+1. Enter the port number that the remote server listens on in **Port**.
+
+1. Select **TCP** or **UDP** from the **Transport Protocol** dropdown. This selection determines which transport protocol is used to send the logs to the remote server.
+
+1. (Optional) Select the **Enable TLS** checkbox to send encrypted logs to remote server with TLS. After you select the checkbox:
+	1. Enter either the name or SHA1 fingerprint of the remote peer in **Permitted Peer**.
+	1. Enter the SSL certificate for the remote server in **SSL Certificate**.
+	<p class="note"><strong>Note:</strong> <%= vars.company_name %> strongly recommends that you enable TLS encryption when you are forwarding logs. Logs can contain sensitive information, such as cloud provider credentials.</p>
+
+1. (Optional) Enter an integer in **Queue Size**. This value specifies the number of log messages held in the buffer. The default value is 100,000.
+
+1. (Optional) Select the checkbox to **Forward Debug Logs** to an external source. This option is deselected by default. If you select it, you may generate a large amount of log data.
+
+1. (Optional) Enter configuration details for rsyslog in the **Custom rsyslog Configuration** field. This field requires the rainerscript syntax.
+
+1. Click **Save**.
 
 ### <a id='pruning'></a> Pruning settings
 


### PR DESCRIPTION
Ops Manager syslog settings does not have the Environment field that tile-based syslog settings does. This inlines the content from the syslog settings partial so that it can vary from that partial.