### PR TITLE
Update the steps to create an azure service principal for ops-manager 2.10

### DIFF
--- a/azure/prepare-azure-terraform.html.md.erb
+++ b/azure/prepare-azure-terraform.html.md.erb
@@ -134,7 +134,6 @@ in <em>Installing <%= vars.ops_manager %> in Air-Gapped Environments</em>.</p>
       "appPermissions": null,
       "availableToOtherTenants": false,
       "displayName": "Service Principal for BOSH",
-      "homepage": "http://BOSHAzureCIP",
       "identifierUris": [
         "http://BOSHAzureCPI"
       ],
@@ -144,70 +143,38 @@ in <em>Installing <%= vars.ops_manager %> in Air-Gapped Environments</em>.</p>
     }
     </pre>
 
+## <a id='create-configure'></a> Step 4: Create and configure a service principal
 
-## <a id='create-credential'></a> Step 4: Create a credential for the ADD app
+1. To create a service principal, run the following command:
 
-1. To create a credential associated with the app, run:
     ```
-    az ad app credential reset --id YOUR-APP-ID
+    az ad sp create-for-rbac --display-name "Service Principal for BOSH" \
+      -n YOUR-APPLICATION-ID \
+      --role Owner \
+      --scopes /subscriptions/SUBSCRIPTION-ID
     ```
-    Where `YOUR-APP-ID` is the `APP_ID` that you recorded in [Create an AAD App](#create-aad).
+
+    Where `YOUR-APPLICATION-ID` is the `APPLICATION_ID` that you recorded in
+    [Create an AAD Application](#create-aad).
 
     For example:
+
     <pre class="terminal">
-    $ az ad app credential reset --id 5c552e8f-b977-45f5-a50b-981cfe17cb9d
-    The output includes credentials that you must protect. Be sure that you do not include these credentials in your code or check the credentials into your source control. For more information, see https://aka.ms/azadsp-cli
-    {
-      "appId": "5c552e8f-b977-45f5-a50b-981cfe17cb9d",
-      "password": "RFy8Q~~Bs.pCVsoKhDNDUIdAveJ2Ig5SkuW4NdhP",
-      "tenant": "22222222-1234-5678-1234-678912345678"
-    }
-    </pre>
-
-1. From the output of `az ad app credential reset` that you ran in the previous step, locate and record the value of `password`. This is your `CLIENT_SECRET` for creating a service principal.
-
-## <a id='create-configure'></a> Step 5: Create and configure a service principal
-
-1. To create a service principal, run:
-
-    ```
-    az ad sp create --id YOUR-APP-ID
-    ```
-    Where `YOUR-APP-ID` is the `APP_ID` that you recorded in [Create an AAD App](#create-aad).
-
-    For example:
-    <pre class="terminal">
-    $ az ad sp create --id 5c552e8f-b977-45f5-a50b-981cfe17cb9d
+    $ az ad sp create-for-rbac --display-name "Service Principal for BOSH" \
+       -n 5c552e8f-b977-45f5-a50b-981cfe17cb9d \
+       --role Owner \
+      --scopes /subscriptions/1e9249d9-c682-410b-8d50-31fda4736c8b
     {
       "appId": "5c552e8f-b977-45f5-a50b-981cfe17cb9d",
       "displayName": "Service Principal for BOSH",
-      "objectId": "cc13c685-4c3b-461e-ae96-7a0563960b83",
-      "objectType": "ServicePrincipal",
-      "servicePrincipalNames": [
-        "5c552e8f-b977-45f5-a50b-981cfe17cb9d",
-        "http://BOSHAzureCPI"
-      ]
+      "password": "9Hf8Q~4kYUPJ7wDqWoBVM5DctJZ~8xAxg8842axC",
+      "tenant": "b39165ca-3cee-4b8a-a4d6-cd1239dd62f0"
     }
     </pre>
 
-1. You must have the Owner role on your service principal to deploy <%= vars.ops_manager %> to Azure.
-To assign the Owner role on your service principal, run:
+    From the output of `az ad sp create-for-rbac` that you ran in the previous step, locate and record the value of `password`. This is your `CLIENT_SECRET` for creating a service principal.
 
-    ```
-    az role assignment create --assignee "SERVICE-PRINCIPAL-NAME" \
-    --role "Owner" --scope /subscriptions/SUBSCRIPTION-ID
-    ```
-    Where:
-    * `SERVICE-PRINCIPAL-NAME` is any value of `servicePrincipalNames` from the output above, such as `YOUR-APP-ID`.
-    * `SUBSCRIPTION-ID` is the value of the `id` of the default subscription that you recorded in [Set Your Default Subscription](#default-subscription).
-
-    For example:
-    <pre class="terminal">
-    $ az role assignment create \
-    --assignee "5c552e8f-b977-45f5-a50b-981cfe17cb9d" \
-    --role "Owner" \
-    --scope /subscriptions/87654321-1234-5678-1234-567891234567
-    </pre>
+    You must have the Owner role on your service principal to deploy <%= vars.ops_manager to Azure.
 
     <p> If you need to use multiple resource groups for your deployment on Azure, you can define custom roles for your Service Principal. These roles enable BOSH to deploy to pre-existing network resources outside of the resource group.</p>
 
@@ -240,7 +207,7 @@ To assign the Owner role on your service principal, run:
     </pre>
 
 
-## <a id='verify-your-service-principal'></a> Step 6: Verify your service principal
+## <a id='verify-your-service-principal'></a> Step 5: Verify your service principal
 
 To verify your service principal, run the following command to log in to your service principal:
 
@@ -251,7 +218,7 @@ az login --username APP_ID --password CLIENT_SECRET \
 Where:
 
 * `APP_ID` is the `APP_ID` that you recorded in [Create an AAD App](#create-aad).
-* `CLIENT_SECRET` is the password that you provided in [Create an AAD App](#create-aad).
+* `CLIENT_SECRET` is the password that you recorded in [Create a service principal](#create-configure).
 * `TENANT_ID` is the value of `tenantID` of the default subscription that you recorded in [Set Your Default Subscription](#default-subscription).
 
 For example:
@@ -278,7 +245,7 @@ $ az login --username 5c552e8f-b977-45f5-a50b-981cfe17cb9d \
 If you cannot log in, the service principal is invalid. Create a new service principal and try again.
 
 
-## <a id='register'></a> Step 7: Complete registrations
+## <a id='register'></a> Step 6: Complete registrations
 
 1. To register your subscription with Microsoft.Storage, run:
 

--- a/azure/prepare-env-manual.html.md.erb
+++ b/azure/prepare-env-manual.html.md.erb
@@ -120,25 +120,22 @@ account to log in to your Azure subscription.
 
     ```
     az ad app create --display-name "Service Principal for BOSH" \
-    --password "PASSWORD" --homepage "http://BOSHAzureCPI" \
+    --web-home-page-url "http://BOSHAzureCPI" \
     --identifier-uris "http://BOSHAzureCPI"
     ```
-
-    Where `PASSWORD` is a password of your choice. This is your `CLIENT_SECRET` for creating a
-    service principal.
 
     For example:
 
     <pre class="terminal">
     $ az ad app create --display-name "Service Principal for BOSH" \
-    --password "Swordfish" --homepage "http://BOSHAzureCPI" \
+    --web-home-page-url "http://BOSHAzureCPI" \
     --identifier-uris "http://BOSHAzureCPI"
     </pre>
 
     <p> You can provide any string for the
-    <code>homepage</code> and <code>identifier-uris</code> flags, but the value of
+    <code>web-home-page-url</code> and <code>identifier-uris</code> flags, but the value of
     <code>identifer-uris</code> must be unique within the organization associated with your Azure
-    subscription. For the <code>homepage</code>, <%= vars.company_name %> recommends using
+    subscription. For the <code>web-home-page-url</code>, <%= vars.company_name %> recommends using
     <code>http://BOSHAzureCPI</code> as shown in the example above.
     </p>
 
@@ -154,7 +151,9 @@ the value of `appId`. This is your `APPLICATION_ID` for creating a service princ
       "appPermissions": null,
       "availableToOtherTenants": false,
       "displayName": "Service Principal for BOSH",
-      "homepage": "http://BOSHAzureCIP",
+      "web": {
+        "homePageUrl": "http://BOSHAzureCIP",
+      },
       "identifierUris": [
         "http://BOSHAzureCPI"
       ],
@@ -169,7 +168,10 @@ the value of `appId`. This is your `APPLICATION_ID` for creating a service princ
 1. To create a service principal, run the following command:
 
     ```
-    az ad sp create --id YOUR-APPLICATION-ID
+    az ad sp create-for-rbac --display-name "Service Principal for BOSH" \
+      -n YOUR-APPLICATION-ID \
+      --role Owner \
+      --scopes /subscriptions/SUBSCRIPTION-ID
     ```
 
     Where `YOUR-APPLICATION-ID` is the `APPLICATION_ID` that you recorded in
@@ -178,43 +180,21 @@ the value of `appId`. This is your `APPLICATION_ID` for creating a service princ
     For example:
 
     <pre class="terminal">
-    $ az ad sp create --id 5c552e8f-b977-45f5-a50b-981cfe17cb9d
+    $ az ad sp create-for-rbac --display-name "Service Principal for BOSH" \
+       -n 5c552e8f-b977-45f5-a50b-981cfe17cb9d \
+       --role Owner \
+      --scopes /subscriptions/1e9249d9-c682-410b-8d50-31fda4736c8b
     {
       "appId": "5c552e8f-b977-45f5-a50b-981cfe17cb9d",
       "displayName": "Service Principal for BOSH",
-      "objectId": "cc13c685-4c3b-461e-ae96-7a0563960b83",
-      "objectType": "ServicePrincipal",
-      "servicePrincipalNames": [
-        "5c552e8f-b977-45f5-a50b-981cfe17cb9d",
-        "http://BOSHAzureCPI"
-      ]
+      "password": "9Hf8Q~4kYUPJ7wDqWoBVM5DctJZ~8xAxg8842axC",
+      "tenant": "b39165ca-3cee-4b8a-a4d6-cd1239dd62f0"
     }
     </pre>
 
-1. You must have the Owner role on your service principal to deploy <%= vars.ops_manager %> to Azure. To assign
-the Owner role on your service principal, run the following command:
+    From the output of `az ad sp create-for-rbac` that you ran in the previous step, locate and record the value of `password`. This is your `CLIENT_SECRET` for creating a service principal.
 
-    ```
-    az role assignment create --assignee "SERVICE-PRINCIPAL-NAME" \
-    --role "Owner" --scope /subscriptions/SUBSCRIPTION-ID
-    ```
-
-    Where:
-
-    * `SERVICE-PRINCIPAL-NAME` is any value of `servicePrincipalNames` from the output above, such
-      as `YOUR-APPLICATION-ID`.
-    * `SUBSCRIPTION-ID` is the value of the `id` of the default subscription that you recorded in
-      [Set Your Default Subscription](#default-subscription).
-
-    For example:
-
-    <pre class="terminal">
-    $ az role assignment create \
-    --assignee "5c552e8f-b977-45f5-a50b-981cfe17cb9d" \
-    --role "Owner" \
-    --scope /subscriptions/87654321-1234-5678-1234-567891234567
-    </pre>
-
+    You must have the Owner role on your service principal to deploy <%= vars.ops_manager to Azure.
     <p> If you need to use multiple resource groups for your
     deployment on Azure, you can define custom roles for your service principal. These roles enable
     BOSH to deploy to pre-existing network resources outside of the resource group.
@@ -264,7 +244,7 @@ Where:
 
 * `APPLICATION_ID` is the `APPLICATION_ID` that you recorded in
   [Create an AAD Application](#create-aad).
-* `CLIENT_SECRET` is the password that you provided in [Create an AAD Application](#create-aad).
+* `CLIENT_SECRET` is the password that you recorded in [Create a service principal](#create-configure).
 * `TENANT_ID` is the value of `tenantID` of the default subscription that you recorded in
   [Set Your Default Subscription](#default-subscription).
 


### PR DESCRIPTION
adjust the instructions based on changes in the az cli now using `az ad sp create-for-rbac` instead of `sp create`

[#184740139]